### PR TITLE
Reorganize the wsgi app creation

### DIFF
--- a/xsnippet/settings.py
+++ b/xsnippet/settings.py
@@ -1,5 +1,0 @@
-# these are 'debug' settings which are used for unit and functional tests
-
-DEBUG = True
-SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-SQLALCHEMY_ECHO = True

--- a/xsnippet/wsgi.py
+++ b/xsnippet/wsgi.py
@@ -1,0 +1,25 @@
+from xsnippet import create_app
+from xsnippet.db import models
+
+
+class ProductionSettings:
+    DEBUG = False
+    SQLALCHEMY_ECHO = False
+
+
+class DebugSettings:
+    DEBUG = True
+    SQLALCHEMY_ECHO = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+
+
+if __name__ == "__main__":
+    app = create_app(DebugSettings)
+
+    # TODO: use alembic for this
+    with app.app_context():
+        models.db.create_all()
+
+    app.run()
+else:
+    app = create_app(ProductionSettings)


### PR DESCRIPTION
Reorganize the wsgi app creation a bit, so that it's easier to
consume it by uwsgi configuration. Allow the development server to be
run as:

   python -m xsnippet.wsgi
