### PR TITLE
tox: avoid building of sdist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,10 @@ envlist =
   py35
 
 [testenv]
+# saves a little time when running tests with an existing virtual environment
+# and allows to modify code in place (e.g. for debugging purposes)
+skipsdist = true
+usedevelop = true
 deps =
   pytest
   pytest-cov
@@ -18,6 +22,7 @@ commands =
   py.test --cov xsnippet_api/ --cov-append tests/
 
 [testenv:swagger]
+usedevelop = false
 skip_install = True
 
 deps =


### PR DESCRIPTION
Skip the step of building of an sdist and install the package in the
development mode (i.e. python setup.py develop) - this allows to
save a little time when running tests and modify files in place (e.g.
for debugging purposes) without running tox again.