### PR TITLE
tox: ensure sdist step is skipped for swagger env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skipsdist = true
 envlist =
   swagger
   py35
@@ -6,7 +7,6 @@ envlist =
 [testenv]
 # saves a little time when running tests with an existing virtual environment
 # and allows to modify code in place (e.g. for debugging purposes)
-skipsdist = true
 usedevelop = true
 deps =
   pytest
@@ -23,7 +23,6 @@ commands =
 
 [testenv:swagger]
 usedevelop = false
-skip_install = True
 
 deps =
   flex


### PR DESCRIPTION
skipsdist is a global var, not an env one. skip_install becomes
redundant now.