### PR TITLE
tests: separate init and cleanup steps from test cases

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ import inspect
 import aiohttp
 
 
-def inloop(fn):
+def inloop(fn=None, *, setup=None, teardown=None):
     """Decorator that runs a wrapped function in the event loop.
 
     Usage::
@@ -26,37 +26,74 @@ def inloop(fn):
             # test_a is executed in the event loop
             pass
 
+        @inloop(setup=spam, teardown=eggs)
+        async def test_b(self):
+            # test_b is executed in the event loop after spam was successfully
+            # executed. When test_b returns, eggs will be executed
+            pass
+
     :param fn: a function to run in the event loop
     :type fn: a function object
 
+    :param setup: a callable to be executed *before* the function. Can also be
+                  a coroutine object, in which case it will be executed in the
+                  context of the created event loop
+    :type setup: a callable object
+
+    :param teardown: a callable object to be executed *after* the function. Can
+                     also be a coroutine object, in which case it will be
+                     executed in the context of the created event loop
+    :type teardown: a callable object
+
     :return: a decorated function
     :rtype: a function object
+
     """
-    @functools.wraps(fn)
-    def _wrapper(*args, **kwargs):
-        def_loop = asyncio.get_event_loop()
-        tmp_loop = asyncio.new_event_loop()
 
-        # set newly created event loop as default one, so we don't need
-        # to pass it explicitly down the call stack
-        asyncio.set_event_loop(tmp_loop)
+    def decorate(fn):
+        @functools.wraps(fn)
+        def _wrapper(self, *args, **kwargs):
+            def_loop = asyncio.get_event_loop()
+            tmp_loop = asyncio.new_event_loop()
 
-        try:
-            rv = tmp_loop.run_until_complete(fn(*args, **kwargs))
+            # set newly created event loop as default one, so we don't need
+            # to pass it explicitly down the call stack
+            asyncio.set_event_loop(tmp_loop)
 
-            # running a given coroutine may produce another ones to free
-            # resources (e.g. close sockets) when it's done, so we need
-            # to run the event loop one more time to execute them
-            tmp_loop.stop()
-            tmp_loop.run_forever()
-            tmp_loop.close()
+            if setup:
+                if inspect.iscoroutinefunction(setup):
+                    tmp_loop.run_until_complete(setup(self))
+                else:
+                    setup(self)
 
-        finally:
-            asyncio.set_event_loop(def_loop)
+            try:
+                try:
+                    rv = tmp_loop.run_until_complete(fn(self, *args, **kwargs))
+                finally:
+                    if teardown:
+                        if inspect.iscoroutinefunction(teardown):
+                            tmp_loop.run_until_complete(teardown(self))
+                        else:
+                            teardown(self)
 
-        return rv
+                # running a given coroutine may produce another ones to free
+                # resources (e.g. close sockets) when it's done, so we need
+                # to run the event loop one more time to execute them
+                tmp_loop.stop()
+                tmp_loop.run_forever()
+                tmp_loop.close()
 
-    return _wrapper
+            finally:
+                asyncio.set_event_loop(def_loop)
+
+            return rv
+
+        return _wrapper
+
+    if fn:
+        return decorate(fn)
+    else:
+        return decorate
 
 
 class AIOTestMeta(type):
@@ -78,12 +115,45 @@ class AIOTestMeta(type):
 
     Regular test cases will be run in usual way, while async ones - inside
     event loop.
+
+    A test class may contain special setup / teardown methods, which will
+    be executed before and after running of each test case::
+
+        class TestSnippets(unittest.TestCase, metaclass=AIOTestMeta):
+
+            def setup(self):
+                self.app = create_app(DEFAULT_CONF)
+
+            def teardown(self):
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(self.app['db'].snippets.drop())
+
+            async def test_a(self):
+                self.assertEqual(42, await my_coro())
+
+    Both setup and teardown can also be coroutine methods, in which case they
+    will automatically be executed in the context of a created event loop::
+
+         class TestSnippets(unittest.TestCase, metaclass=AIOTestMeta):
+
+            def setup(self):
+                self.app = create_app(DEFAULT_CONF)
+
+            async def teardown(self):
+                await self.app['db'].snippets.drop()
+
+            async def test_a(self):
+                self.assertEqual(42, await my_coro())
+
     """
 
     def __new__(mcls, name, bases, namespace):
+        setup = namespace.pop('setup', None)
+        teardown = namespace.pop('teardown', None)
+
         for key, value in namespace.items():
             if inspect.iscoroutinefunction(value):
-                namespace[key] = inloop(value)
+                namespace[key] = inloop(setup=setup, teardown=teardown)(value)
 
         return super(AIOTestMeta, mcls).__new__(mcls, name, bases, namespace)
 


### PR DESCRIPTION
Move the repeating initialization (e.g. app creation) and clean up
steps (e.g. DB cleanup) into setup() / teardown() method helpers,
which will be executed before and after each test case.

setup() / teardown() must be aware of the event loop instance which
was created for a particular test case, so that they can execute
appropriate actions (e.g. clean up a DB), thus, setup() / teardown()
are executed by the inloop() decorator.