### PR TITLE
Add 'pool-size' to default.conf

### DIFF
--- a/xsnippet_api/database.py
+++ b/xsnippet_api/database.py
@@ -24,7 +24,8 @@ def create_connection(conf):
     :rtype: :class:`motor.motor_asyncio.AsyncIOMotorDatabase`
     """
 
-    mongo = AsyncIOMotorClient(conf['database']['connection'])
+    mongo = AsyncIOMotorClient(conf['database']['connection'],
+                               max_pool_size=conf['database']['pool-size'])
 
     # get_default_database returns a database from the connection string
     db = mongo.get_default_database()

--- a/xsnippet_api/default.conf
+++ b/xsnippet_api/default.conf
@@ -21,3 +21,9 @@ port = 8000
 ;
 ; Supported backends: MongoDB only
 connection = mongodb://localhost:27017/xsnippet
+
+; MAXIMUM NUMBER OF CONNECTIONS
+;
+; Operations will block if there are 'pool-size' outstanding connections
+; from the pool.
+pool-size = 100


### PR DESCRIPTION
It's very convenient to setup such options like 'pool-size' through
configuration file, since one might want to turn it taking into
account server resources.