### PR TITLE
Do not pass down event loop, use default one

### DIFF
--- a/xsnippet_api/application.py
+++ b/xsnippet_api/application.py
@@ -15,23 +15,20 @@ from . import database
 from . import resources
 
 
-def create_app(conf, loop=None):
+def create_app(conf):
     """Create and return a web application instance.
 
     The whole point of that function is to provide a way to create
-    an application instance using some external context such as
-    settings or event loop to run in.
+    a full-featured application instance with database sesstion,
+    routes and so on.
 
     :param conf: a settings to be used to create an application instance
     :type conf: :class:`dict`
 
-    :param loop: an event loop to run in
-    :type loop: :class:`asyncio.BaseEventLoop` or None
-
     :return: an application instance
     :rtype: :class:`aiohttp.web.Application`
     """
-    app = web.Application(loop=loop)
+    app = web.Application()
 
     app.router.add_route(
         '*', '/snippets', resources.Snippets, name='snippets')
@@ -39,6 +36,6 @@ def create_app(conf, loop=None):
     # attach settings to the application instance in order to make them
     # accessible at any point of execution (e.g. request handling)
     app['conf'] = conf
-    app['db'] = database.create_connection(conf, loop=loop)
+    app['db'] = database.create_connection(conf)
 
     return app

--- a/xsnippet_api/database.py
+++ b/xsnippet_api/database.py
@@ -9,32 +9,22 @@
     :license: MIT, see LICENSE for details
 """
 
-import asyncio
-
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo.son_manipulator import SONManipulator
 import pymongo
 
 
-def create_connection(conf, loop=None):
+def create_connection(conf):
     """Create and return a database connection.
 
     :param conf: a settings to be used to create an application instance
     :type conf: :class:`dict`
 
-    :param loop: an event loop to run in
-    :type loop: :class:`asyncio.BaseEventLoop` or None
-
     :return: a database connection
     :rtype: :class:`motor.motor_asyncio.AsyncIOMotorDatabase`
     """
 
-    # NOTE(malor): motor won't use the default event loop if None is passed.
-    # Use a workaround here, until it's fixed in upstream.
-    if loop is None:
-        loop = asyncio.get_event_loop()
-
-    mongo = AsyncIOMotorClient(conf['database']['connection'], io_loop=loop)
+    mongo = AsyncIOMotorClient(conf['database']['connection'])
 
     # get_default_database returns a database from the connection string
     db = mongo.get_default_database()


### PR DESCRIPTION
Having possibility to pass down custom event loop looks like unnecessary
complication that requires ugly workaround (see one with Motor). Let's
remove it, and may the code a little more event-loop agnostic.