### PR TITLE
Pass concurrency=greenlet to coverage.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = true
+source =
+    xsnippet_api/
+
+; Motor uses greenlet under the hood, and that makes coverage crazy, so
+; it wrongly reports missed statements.
+concurrency = greenlet

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ services:
   - mongodb
 
 install:
-  - pip install tox coveralls
+  # greenlet is needed to submit concurrency=greenlet based coverage
+  # to coveralls.io service
+  - pip install tox coveralls greenlet
 
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
 # check that pep8 and other checks are passed
   flake8 xsnippet_api/ tests/
 # check that unittests are passed
-  py.test --cov xsnippet_api/ --cov-append tests/
+  py.test tests/ --cov --cov-append
 
 [testenv:swagger]
 usedevelop = false


### PR DESCRIPTION
So far coverage wrongly reports missed statements, and shows a bunch of
create_index calls as unevaluated. We know for sure they have been
executed, since otherwise tests will fail.

According to coverage documentation, it easily can be confused if greenlet
is used. In that case we should explicitly tell coverage that
concurrency model is greenlet.

Unfortunately, this is the case. Motor uses greenlet under the hood, and
passing concurrency=greenlet to coverage solves the issue.