### PR TITLE
Add a basic implementation of the Snippet resource

### DIFF
--- a/xsnippet_api/application.py
+++ b/xsnippet_api/application.py
@@ -32,6 +32,8 @@ def create_app(conf):
 
     app.router.add_route(
         '*', '/snippets', resources.Snippets, name='snippets')
+    app.router.add_route(
+        '*', '/snippets/{id}', resources.Snippet, name='snippet')
 
     # attach settings to the application instance in order to make them
     # accessible at any point of execution (e.g. request handling)

--- a/xsnippet_api/resources/__init__.py
+++ b/xsnippet_api/resources/__init__.py
@@ -8,9 +8,10 @@
     :license: MIT, see LICENSE for details
 """
 
-from .snippets import Snippets
+from .snippets import Snippet, Snippets
 
 
 __all__ = [
+    'Snippet',
     'Snippets',
 ]

--- a/xsnippet_api/resources/snippets.py
+++ b/xsnippet_api/resources/snippets.py
@@ -9,7 +9,24 @@
     :license: MIT, see LICENSE for details
 """
 
+import aiohttp.web as web
+
 from .resource import Resource
+
+
+class Snippet(Resource):
+
+    async def get(self):
+        try:
+            _id = int(self.request.match_info['id'])
+        except (ValueError, TypeError):
+            raise web.HTTPBadRequest()
+
+        snippet = await self.db.snippets.find_one({'_id': _id})
+        if snippet is None:
+            raise web.HTTPNotFound()
+
+        return self.make_response(snippet)
 
 
 class Snippets(Resource):


### PR DESCRIPTION
Only GET requests are supported now. We'll also need to refactor
errors to be in JSON format.