### PR TITLE
Calesce together commit authors using .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Roman Podoliaka <roman.podolyaka@gmail.com> <rpodolyaka@mirantis.com>


### PR DESCRIPTION
The .mailmap feature is used to coalesce together commits by the same
person in the shortlog, where their name and/or email address was
spelled differently. So far '$ git shortlog -se' shows the following
output:

    15  Igor Kalnitsky <igor@kalnitsky.org>
     6  Roman Podoliaka <roman.podolyaka@gmail.com>
     6  Roman Podoliaka <rpodolyaka@mirantis.com>

while this commit corrects it to be the following one:

    16  Igor Kalnitsky <igor@kalnitsky.org>
    12  Roman Podoliaka <roman.podolyaka@gmail.com>