### PR TITLE
Add marker based pagination support to /snippets

### DIFF
--- a/tests/services/test_snippet.py
+++ b/tests/services/test_snippet.py
@@ -40,8 +40,8 @@ class TestSnippet(metaclass=AIOTestMeta):
                 'tags': ['tag_a', 'tag_b'],
                 'author_id': None,
                 'is_public': True,
-                'created_at': now,
-                'updated_at': now,
+                'created_at': now - datetime.timedelta(100),
+                'updated_at': now - datetime.timedelta(100),
             },
             {
                 'id': 2,
@@ -51,8 +51,8 @@ class TestSnippet(metaclass=AIOTestMeta):
                 'tags': ['tag_c'],
                 'author_id': None,
                 'is_public': True,
-                'created_at': now + datetime.timedelta(100),
-                'updated_at': now + datetime.timedelta(100),
+                'created_at': now,
+                'updated_at': now,
             },
         ]
 
@@ -95,6 +95,26 @@ class TestSnippet(metaclass=AIOTestMeta):
 
         assert len(returned_snippets) == 1
         assert returned_snippets == [snippet]
+
+    async def test_get_pagination(self):
+        snippet = {
+            'title': 'my snippet',
+            'content': '...',
+            'syntax': 'python',
+        }
+        created = await self.service.create(snippet)
+
+        one = await self.service.get(limit=1)
+        assert len(one) == 1
+        assert one == [created]
+
+        two = await self.service.get(marker=one[0]['id'])
+        assert len(two) == 2
+        assert two == list(reversed(self.snippets))
+
+    async def test_get_pagination_not_found(self):
+        with pytest.raises(web.HTTPNotFound):
+            await self.service.get(limit=10, marker=123456789)
 
     async def test_create(self):
         snippet = {

--- a/xsnippet_api/resources/snippets.py
+++ b/xsnippet_api/resources/snippets.py
@@ -41,7 +41,15 @@ class Snippet(Resource):
 class Snippets(Resource):
 
     async def get(self):
-        snippets = await services.Snippet(self.db).get(limit=20)
+        try:
+            # TODO: get value from conf
+            marker = int(self.request.GET.get('marker', 0))
+            limit = min(int(self.request.GET.get('limit', 20)), 20)
+        except (ValueError, TypeError):
+            raise web.HTTPBadRequest()
+
+        snippets = await services.Snippet(self.db).get(limit=limit,
+                                                       marker=marker)
         return self.make_response(snippets, status=200)
 
     async def post(self):


### PR DESCRIPTION
It's now possible to pass additional ``limit`` and ``marker`` query
parameters to /snippets endpoint, e.g.:

    GET /snippets?limit=10&marker=1234

where ``limit`` will be an upper bound for the number of snippets to
be returned and ``marker`` is the ``id`` of the last snippet seen on
the previous page. Snippets are ordered by the creation order (newer
ones will be returned first).

Marker based pagination is used instead of limit/offset one, as the
performance of the latter degrades quickly as the number of entries
grows.