### PR TITLE
Improve setup.py code and its metadata options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,6 @@
 # coding: utf-8
 
 import os
-
-# tox is usually installed in python2 environment, so it's better
-# to maintain python2 compatibility in setup.py
-from io import open
 from setuptools import setup, find_packages
 
 from xsnippet_api import __version__ as version
@@ -18,52 +14,43 @@ with open(os.path.join(here, 'README.rst'), 'r', encoding='utf-8') as f:
 
 
 setup(
-    name='xsnippet_api',
+    name='xsnippet-api',
     version=version,
-
-    description='XSnippet is a simple web-service for code snippets sharing.',
+    description=(
+        'XSnippet is a simple web-service for sharing code snippets on the '
+        'Internet. Written for fun using bleeding edge technologies.'),
     long_description=long_description,
     license=license,
-    url='http://github.com/xsnippet/xsnippet-api/',
+    url='https://github.com/xsnippet/xsnippet-api/',
     keywords='web-service restful-api snippet storage',
-
     author='The XSnippet Team',
     author_email='dev@xsnippet.org',
-
     packages=find_packages(exclude=['docs', 'tests*']),
     include_package_data=True,
     zip_safe=False,
-
     setup_requires=[
         'pytest-runner',
     ],
-
     install_requires=[
         'aiohttp >= 0.21.2',
         'motor >= 0.5',
         'werkzeug >= 0.11.4',
     ],
-
     tests_require=[
         'pytest >= 2.8.7',
     ],
-
     entry_points={
         'console_scripts': [
             'xsnippet-api = xsnippet_api.__main__:main',
         ],
     },
-
     classifiers=[
         'Environment :: Web Environment',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Information Technology',
-
         'Topic :: Internet :: WWW/HTTP',
-
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',

--- a/xsnippet_api/__main__.py
+++ b/xsnippet_api/__main__.py
@@ -29,7 +29,7 @@ def main(args=sys.argv[1:]):
         port=conf['server']['port'])
 
 
-# let's make this module and git_pr package to be executable, so anyone
-# can run it  without entry_points' console script
+# let's make this module and xsnippet_api package to be executable, so
+# anyone can run it  without entry_points' console script
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* `io.open` is not used anymore in setup.py since we are py3-only project.
* Unnecessary empty lines between setup's options are removed.
* Package short description is more readable now.
* Package name is changed to 'xsnippet-api'.