### PR TITLE
Discover RESTful API via @endpoint decorator

### DIFF
--- a/xsnippet_api/application.py
+++ b/xsnippet_api/application.py
@@ -9,9 +9,12 @@
     :license: MIT, see LICENSE for details
 """
 
+import collections
+import pkg_resources
+
 from aiohttp import web, web_urldispatcher
 
-from . import database, resources, router
+from . import database, router
 
 
 def create_app(conf):
@@ -27,15 +30,10 @@ def create_app(conf):
     :return: an application instance
     :rtype: :class:`aiohttp.web.Application`
     """
-    router_v1 = web_urldispatcher.UrlDispatcher()
-    router_v1.add_route('*', '/snippets', resources.Snippets)
-    router_v1.add_route('*', '/snippets/{id}', resources.Snippet)
-
-    app = web.Application(router=router.VersionRouter(
-        {
-            '1': router_v1,
-        }
-    ))
+    # we need to import all the resources in order to evaluate @endpoint
+    # decorator, so they can be collected and passed to VersionRouter
+    from . import resources  # noqa
+    app = web.Application(router=router.VersionRouter(endpoint.collect()))
 
     # attach settings to the application instance in order to make them
     # accessible at any point of execution (e.g. request handling)
@@ -43,3 +41,61 @@ def create_app(conf):
     app['db'] = database.create_connection(conf)
 
     return app
+
+
+class endpoint:
+    """Define a RESTful API endpoint.
+
+    Usage example:
+
+        @endpoint('/myresources/{id}', '1.0')
+        class MyResource(web.View):
+            def get(self):
+                pass
+
+    :param route: a route to a wrapped resource
+    :param version: initial supported API version
+    :param end_version: last supported version; latest version if None
+    """
+
+    _Item = collections.namedtuple('ResourceItem', [
+        'resource',
+        'route',
+        'version',
+        'end_version',
+    ])
+
+    _registry = []
+
+    def __init__(self, route, version, end_version=None):
+        self._options = (route, version, end_version)
+
+    def __call__(self, resource):
+        self._registry.append(self._Item(resource, *self._options))
+        return resource
+
+    @classmethod
+    def collect(cls):
+        rv = collections.defaultdict(web_urldispatcher.UrlDispatcher)
+
+        # Create routers for each discovered API version. The main reason why
+        # we need that so early is to register resources in all needed routers
+        # according to supported version range.
+        for item in cls._registry:
+            rv[item.version]
+
+        for item in cls._registry:
+            # if there's no end_version then a resource is still working, and
+            # latest discovered version should be considered as end_version
+            end_version = item.end_version or sorted(
+                rv.keys(),
+                key=pkg_resources.parse_version
+            )[-1]
+
+            V = pkg_resources.parse_version
+
+            for version in rv.keys():
+                if V(item.version) <= V(version) <= V(end_version):
+                    rv[version].add_route('*', item.route, item.resource)
+
+        return rv

--- a/xsnippet_api/resources/snippets.py
+++ b/xsnippet_api/resources/snippets.py
@@ -12,8 +12,10 @@
 import aiohttp.web as web
 
 from .. import resource, services
+from ..application import endpoint
 
 
+@endpoint('/snippets/{id}', '1.0')
 class Snippet(resource.Resource):
 
     async def get(self):
@@ -37,6 +39,7 @@ class Snippet(resource.Resource):
         return self.make_response('', status=204)  # No Content
 
 
+@endpoint('/snippets', '1.0')
 class Snippets(resource.Resource):
 
     async def get(self):

--- a/xsnippet_api/router.py
+++ b/xsnippet_api/router.py
@@ -10,8 +10,9 @@
     :license: MIT, see LICENSE for details
 """
 
+import pkg_resources
+
 from aiohttp import abc, web
-from pkg_resources import packaging
 
 
 def _get_latest_version(versions, stable=True):
@@ -36,7 +37,7 @@ def _get_latest_version(versions, stable=True):
     # anyone would use complex API versions (with alpha/beta notation),
     # it still better to implement things correctly and return original
     # representation. That's why we save version pairs here.
-    versions = ((v, packaging.version.parse(v)) for v in versions)
+    versions = ((v, pkg_resources.parse_version(v)) for v in versions)
 
     # Both PEP-440 and SemVer define so called "pre-release" version such
     # as alpha or beta. Most of the time, we aren't interested in them


### PR DESCRIPTION
It's generally a more convenient to do API discovering rather than
importing resources one by one and adding it to router. That makes even
more sense in light of versioning API, where the very same resource may
appear in different routers.

This commit introduces an @endpoint decorator for resources. That allows
us to declaratively map a resource to some URI and defines an API
version range where it's applicable.

No tests are introduces, since those code is explicitly covered by any
test that use create_app() factory function.