### PR TITLE
Respond with 'Vary' HTTP header

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,42 @@
+"""
+    tests.test_application
+    ----------------------
+
+    Tests XSnippet application nuances.
+
+    :copyright: (c) 2016 The XSnippet Team, see AUTHORS for details
+    :license: MIT, see LICENSE for details
+"""
+
+import pytest
+import pkg_resources
+
+from xsnippet_api import application, conf
+from tests import AIOTestMeta, AIOTestApp
+
+
+class TestApplication(metaclass=AIOTestMeta):
+
+    conf = conf.get_conf(
+        pkg_resources.resource_filename('xsnippet_api', 'default.conf'))
+
+    def setup(self):
+        self.app = application.create_app(self.conf)
+
+    @pytest.mark.parametrize('name, value', [
+        ('Accept', 'application/json'),
+        ('Accept-Encoding', 'gzip'),
+        ('X-Api-Version', '1'),
+    ])
+    async def test_http_vary_header(self, name, value):
+        async with AIOTestApp(self.app) as testapp:
+            resp = await testapp.get('/', headers={
+                name: value,
+            })
+
+            parts = set([
+                hdr.strip() for hdr in resp.headers['Vary'].split(',')
+            ])
+
+            assert name in parts
+            resp.close()

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -9,9 +9,9 @@
 """
 
 import json
-import pkg_resources
 
-from aiohttp import web
+import aiohttp.web as web
+import pkg_resources
 
 from xsnippet_api import conf, database, resource
 from tests import AIOTestMeta, AIOTestApp


### PR DESCRIPTION
The Vary HTTP response header determines how to match future request
headers to decide whether a cached response can be used rather than
requesting a fresh one from the origin server. It is used by the server
to indicate which headers it used when selecting a representation of a
resource in a content negotiation algorithm.

This commit adds three Varying headers: Accept, Accept-Encoding and
X-Api-Version.