### PR TITLE
Bump Motor version to at least 0.7

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,10 +1,3 @@
 [run]
 branch = true
-source =
-    xsnippet_api/
-
-; Motor uses greenlet under the hood, and that makes coverage crazy, so
-; it wrongly reports missed statements.
-;
-; http://coverage.readthedocs.io/en/coverage-4.1/config.html?highlight=greenlet#run
-concurrency = greenlet
+source = xsnippet_api/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ services:
   - mongodb
 
 install:
-  # see 'concurrency=greenlet' option in .coveragerc for reason behind greenlet
-  - pip install tox coveralls greenlet
+  - pip install tox coveralls
 
 script:
   - tox

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'aiohttp >= 0.21.2',
         'cerberus >= 0.9.2',
-        'motor >= 0.5',
+        'motor >= 0.7',
         'python-jose >= 1.3.2',
         'werkzeug >= 0.11.4',
     ],


### PR DESCRIPTION
There are two reasons why it's necessary (yet not mandatory) to update
lower bound of Motor version. Here they are:

* Since Motor 0.7 there's another mechanism behind offloading queries to
  MongoDB: previously used greenlets-based approach have been replaced with
  thread pool one.

      https://emptysqua.re/blog/motor-0-7/

  According to the author blog post it improves performance when client
  and database has a good connectivity.

* Moving away from greenlets means we can forget about out hacks around
  coverage.py which affects both .coveragerc and .travis.yml.