### PR TITLE
db: create indexes at application startup

### DIFF
--- a/tests/resources/test_snippets.py
+++ b/tests/resources/test_snippets.py
@@ -85,9 +85,9 @@ class TestSnippets(metaclass=AIOTestMeta):
             assert await resp.json() == []
 
     async def test_get_snippets(self):
-        await self.app['db'].snippets.insert(self.snippets)
-
         async with AIOTestApp(self.app) as testapp:
+            await self.app['db'].snippets.insert(self.snippets)
+
             resp = await testapp.get(
                 '/snippets',
                 headers={
@@ -117,9 +117,10 @@ class TestSnippets(metaclass=AIOTestMeta):
             'created_at': now,
             'updated_at': now,
         }
-        await self.app['db'].snippets.insert(self.snippets + [snippet])
 
         async with AIOTestApp(self.app) as testapp:
+            await self.app['db'].snippets.insert(self.snippets + [snippet])
+
             # ask for one latest snippet
             resp = await testapp.get(
                 '/snippets?limit=1',
@@ -317,19 +318,20 @@ class TestSnippets(metaclass=AIOTestMeta):
                 error_resp['message'])
 
     async def test_data_model_indexes_exist(self):
-        res = await self.app['db'].snippets.index_information()
+        async with AIOTestApp(self.app):
+            res = await self.app['db'].snippets.index_information()
 
-        assert res['author_idx']['key'] == [('author_id', 1)]
-        assert res['tags_idx']['key'] == [('tags', 1)]
-        assert res['updated_idx']['key'] == [('updated_at', -1)]
-        assert res['created_idx']['key'] == [('created_at', -1)]
+            assert res['author_idx']['key'] == [('author_id', 1)]
+            assert res['tags_idx']['key'] == [('tags', 1)]
+            assert res['updated_idx']['key'] == [('updated_at', -1)]
+            assert res['created_idx']['key'] == [('created_at', -1)]
 
     async def test_get_snippet(self):
         awaited = copy.deepcopy(self.snippets[0])
 
-        await self.app['db'].snippets.insert(self.snippets)
-
         async with AIOTestApp(self.app) as testapp:
+            await self.app['db'].snippets.insert(self.snippets)
+
             resp = await testapp.get(
                 '/snippets/' + str(awaited['id']),
                 headers={
@@ -369,9 +371,9 @@ class TestSnippets(metaclass=AIOTestMeta):
 
     async def test_delete_snippet(self):
         created = self.snippets[0]
-        await self.app['db'].snippets.insert(created)
-
         async with AIOTestApp(self.app) as testapp:
+            await self.app['db'].snippets.insert(created)
+
             resp = await testapp.delete(
                 '/snippets/' + str(created['id']),
                 headers={

--- a/xsnippet_api/application.py
+++ b/xsnippet_api/application.py
@@ -76,7 +76,7 @@ def create_app(conf):
     # Attach settings to the application instance in order to make them
     # accessible at any point of execution (e.g. request handling).
     app['conf'] = conf
-    app['db'] = database.create_connection(conf)
+    app.on_startup.append(database.setup)
 
     # We need to respond with Vary header time to time in order to avoid
     # issues with cache on client side.


### PR DESCRIPTION
We currently mix synchronous and asynchronous code in
create_connection(), that leads to sporadic warnings in tests due to
the fact that `on_done` future callbacks are called after the event
loop instance is already closed. Apparently these futures returned
by create_index() are not awaited by the event loop as it is, so we'd
better do it explicitly, rather than hope that callbacks will be
called in time before the event loop is closed.

With this change applied I no longer run into the default limit for
the number of connections opened to mongod at the same time when
running tox -epy36.