### PR TITLE
Use .mailmap to fix three Ihor(s) and two Roman(s)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,3 @@
-Roman Podoliaka <roman.podolyaka@gmail.com> <rpodolyaka@mirantis.com>
+Ihor Kalnytskyi <ihor@kalnytskyi.com> <igor@kalnitsky.org>
+Roman Podoliaka <roman.podoliaka@gmail.com> <roman.podolyaka@gmail.com>
+Roman Podoliaka <roman.podoliaka@gmail.com> <rpodolyaka@mirantis.com>


### PR DESCRIPTION
Due to various name spelling and/or using various emails, Git thinks
that we have plenty of contributors. For instance, here's what it
prints on `git shortlog -se` command:

    40  Igor Kalnitsky <igor@kalnitsky.org>
    14  Ihor Kalnytskyi <igor@kalnitsky.org>
     1  Ihor Kalnytskyi <ihor@kalnytskyi.com>
     6  Roman Podoliaka <roman.podoliaka@gmail.com>
    20  Roman Podoliaka <roman.podolyaka@gmail.com>

Let's merge those authors using `.mailmap` and enjoy pretty, correct and
up-to-date information:

    56  Ihor Kalnytskyi <ihor@kalnytskyi.com>
    26  Roman Podoliaka <roman.podoliaka@gmail.com>