### PR TITLE
Implement PUT & PATCH for /snippets/{id} endpoint

### DIFF
--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -10,6 +10,12 @@ def appinstance():
     conf = get_conf(
         pkg_resources.resource_filename('xsnippet.api', 'default.conf'))
     conf['auth'] = {'secret': 'SWORDFISH'}
+
+    # This flag exist to workaround permissions (which we currently lack of)
+    # and test PUT/PATCH requests to the snippet. Once permissions are
+    # implemented and the hack is removed from @checkpermissions decorator
+    # in resources/snippets.py - this hack must be thrown away.
+    conf['test'] = {'sudo': True}
     return create_app(conf)
 
 

--- a/tests/resources/test_snippets.py
+++ b/tests/resources/test_snippets.py
@@ -384,10 +384,7 @@ async def test_post_snippet_malformed_snippet(name, value, testapp, snippets):
     assert resp.status == 400
 
     error_resp = await resp.json()
-    assert re.match(
-        'Cannot create a new snippet, passed data are incorrect. '
-        'Found issues: `%s` - .*' % name,
-        error_resp['message'])
+    assert re.match('`%s` - .*' % name, error_resp['message'])
 
 
 async def test_post_snippet_syntax_enum_allowed(
@@ -437,10 +434,7 @@ async def test_post_snippet_syntax_enum_not_allowed(
     assert resp.status == 400
 
     error_resp = await resp.json()
-    assert re.match(
-        'Cannot create a new snippet, passed data are incorrect. '
-        'Found issues: `syntax` - invalid value.',
-        error_resp['message'])
+    assert re.match('`syntax` - .*', error_resp['message'])
 
 
 async def test_data_model_indexes_exist(db):
@@ -532,3 +526,341 @@ async def test_delete_snippet_bad_request(testapp):
     assert await resp.json() == {
         'message': '`id` - must be of integer type.'
     }
+
+
+async def test_put_snippet(testapp, snippets, db):
+    await db.snippets.insert(snippets)
+
+    resp = await testapp.put(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'content': 'brand new snippet',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 200
+
+    snippet_resp = await resp.json()
+    snippet_db = await db.snippets.find_one(
+        {'_id': snippet_resp['id']}
+    )
+
+    _compare_snippets(snippet_db, snippet_resp)
+
+
+async def test_put_snippet_bad_id(testapp):
+    resp = await testapp.put(
+        '/snippets/deadbeef',
+        data=json.dumps({
+            'content': 'brand new snippet',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        }
+    )
+    assert resp.status == 400
+    assert await resp.json() == {
+        'message': '`id` - must be of integer type.'
+    }
+
+
+async def test_put_snippet_not_found(testapp):
+    resp = await testapp.put(
+        '/snippets/0123456789',
+        data=json.dumps({
+            'content': 'brand new snippet',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        }
+    )
+    assert resp.status == 404
+    assert await resp.json() == {
+        'message': 'Sorry, cannot find the requested snippet.',
+    }
+
+
+@pytest.mark.parametrize('name, val', [
+    ('title', 42),                          # must be string
+    ('content', 42),                        # must be string
+    ('tags', ['a tag with whitespaces']),   # tag must not contain spaces
+    ('created_at', '2016-09-11T19:07:43'),  # readonly
+    ('updated_at', '2016-09-11T19:07:43'),  # readonly
+    ('non-existent-key', 'must not be accepted'),
+])
+async def test_put_snippet_malformed_snippet(name, val, testapp, snippets, db):
+    await db.snippets.insert(snippets)
+
+    snippet = {'content': 'brand new snippet'}
+    snippet[name] = val
+
+    resp = await testapp.put(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps(snippet),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 400
+
+    error_resp = await resp.json()
+    assert re.match('`%s` - .*' % name, error_resp['message'])
+
+
+@pytest.mark.parametrize('name', [
+    'content',
+])
+async def test_put_snippet_required_fields(name, testapp, snippets, db):
+    await db.snippets.insert(snippets)
+
+    snippet = copy.deepcopy(snippets[0])
+    for key in ('id', 'created_at', 'updated_at'):
+        del snippet[key]
+    del snippet[name]
+
+    resp = await testapp.put(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps(snippet),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 400
+
+    error_resp = await resp.json()
+    assert re.match(
+        '`%s` - required field.' % name, error_resp['message'])
+
+
+async def test_put_snippet_syntax_enum_allowed(
+        testapp, snippets, db, appinstance):
+    appinstance['conf']['snippet']['syntaxes'] = 'python\nclojure'
+
+    await db.snippets.insert(snippets)
+
+    resp = await testapp.put(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'content': 'brand new snippet',
+            'syntax': 'python',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 200
+
+    snippet_resp = await resp.json()
+    snippet_db = await db.snippets.find_one(
+        {'_id': snippet_resp['id']}
+    )
+    _compare_snippets(snippet_db, snippet_resp)
+
+
+async def test_put_snippet_syntax_enum_not_allowed(
+        testapp, snippets, db, appinstance):
+    appinstance['conf']['snippet']['syntaxes'] = 'python\nclojure'
+
+    await db.snippets.insert(snippets)
+
+    resp = await testapp.put(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'content': 'brand new snippet',
+            'syntax': 'go',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 400
+
+    error_resp = await resp.json()
+    assert re.match(
+        '`syntax` - unallowed value go.', error_resp['message'])
+
+
+async def test_patch_snippet(testapp, snippets, db):
+    await db.snippets.insert(snippets)
+
+    resp = await testapp.patch(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'content': 'brand new snippet',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 200
+
+    snippet_resp = await resp.json()
+    snippet_db = await db.snippets.find_one(
+        {'_id': snippet_resp['id']}
+    )
+    _compare_snippets(snippet_db, snippet_resp)
+
+
+async def test_patch_snippet_bad_id(testapp):
+    resp = await testapp.patch(
+        '/snippets/deadbeef',
+        data=json.dumps({
+            'content': 'brand new snippet',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        }
+    )
+    assert resp.status == 400
+    assert await resp.json() == {
+        'message': '`id` - must be of integer type.'
+    }
+
+
+async def test_patch_snippet_not_found(testapp):
+    resp = await testapp.patch(
+        '/snippets/0123456789',
+        data=json.dumps({
+            'content': 'brand new snippet',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        }
+    )
+    assert resp.status == 404
+    assert await resp.json() == {
+        'message': 'Sorry, cannot find the requested snippet.',
+    }
+
+
+@pytest.mark.parametrize('name, value', [
+    ('title', 42),                          # must be string
+    ('content', 42),                        # must be string
+    ('tags', ['a tag with whitespaces']),   # tag must not contain spaces
+    ('created_at', '2016-09-11T19:07:43'),  # readonly
+    ('updated_at', '2016-09-11T19:07:43'),  # readonly
+    ('non-existent-key', 'must not be accepted'),
+])
+async def test_patch_snippet_malformed_snippet(
+        name, value, testapp, snippets, db):
+    await db.snippets.insert(snippets)
+
+    snippet = {'content': 'brand new snippet'}
+    snippet[name] = value
+
+    resp = await testapp.patch(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps(snippet),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 400
+
+    error_resp = await resp.json()
+    assert re.match('`%s` - .*' % name, error_resp['message'])
+
+
+async def test_patch_snippet_required_fields_are_not_forced(
+        testapp, snippets, db):
+    await db.snippets.insert(snippets)
+
+    resp = await testapp.patch(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'title': 'brand new snippet',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 200
+
+    snippet_resp = await resp.json()
+    snippet_db = await db.snippets.find_one(
+        {'_id': snippet_resp['id']}
+    )
+    _compare_snippets(snippet_db, snippet_resp)
+
+
+async def test_patch_snippet_syntax_enum_allowed(
+        testapp, snippets, db, appinstance):
+    appinstance['conf']['snippet']['syntaxes'] = 'python\nclojure'
+
+    await db.snippets.insert(snippets)
+
+    resp = await testapp.patch(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'content': 'brand new snippet',
+            'syntax': 'python',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 200
+
+    snippet_resp = await resp.json()
+    snippet_db = await db.snippets.find_one(
+        {'_id': snippet_resp['id']}
+    )
+
+    _compare_snippets(snippet_db, snippet_resp)
+
+
+async def test_patch_snippet_syntax_enum_not_allowed(
+        testapp, snippets, db, appinstance):
+    appinstance['conf']['snippet']['syntaxes'] = 'python\nclojure'
+
+    await db.snippets.insert(snippets)
+
+    resp = await testapp.patch(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'content': 'brand new snippet',
+            'syntax': 'go',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 400
+
+    error_resp = await resp.json()
+    assert re.match(
+        '`syntax` - unallowed value go.', error_resp['message'])
+
+
+@pytest.mark.parametrize('method', [
+    'put',
+    'patch',
+    'delete',
+])
+async def test_snippet_update_is_not_exposed(
+        method, testapp, snippets, appinstance, db):
+    appinstance['conf'].remove_option('test', 'sudo')
+    await db.snippets.insert(snippets)
+
+    request = getattr(testapp, method)
+
+    resp = await request(
+        '/snippets/' + str(snippets[0]['id']),
+        data=json.dumps({
+            'content': 'brand new snippet',
+            'syntax': 'go',
+        }),
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+    assert resp.status == 403
+
+    error_resp = await resp.json()
+    assert error_resp['message'] == 'Not yet. :)'

--- a/xsnippet/api/resources/snippets.py
+++ b/xsnippet/api/resources/snippets.py
@@ -9,6 +9,8 @@
     :license: MIT, see LICENSE for details
 """
 
+import functools
+
 import cerberus
 
 from .misc import cerberus_errors_to_str, try_int
@@ -16,42 +18,118 @@ from .. import exceptions, resource, services
 from ..application import endpoint
 
 
-_schema = {
-    'id': {'type': 'integer', 'readonly': True},
-    'title': {'type': 'string'},
-    'content': {'type': 'string', 'required': True},
-    'syntax': {'type': 'string'},
-    'tags': {'type': 'list', 'schema': {'type': 'string', 'regex': '[\w_-]+'}},
-    'created_at': {'type': 'datetime', 'readonly': True},
-    'updated_at': {'type': 'datetime', 'readonly': True},
-}
+class InvalidId(Exception):
+    pass
+
+
+def _get_id(resource):
+    v = cerberus.Validator({
+        'id': {'type': 'integer', 'min': 1, 'coerce': try_int},
+    })
+
+    if not v.validate(dict(resource.request.match_info)):
+        raise InvalidId('%s.' % cerberus_errors_to_str(v.errors))
+
+    return int(resource.request.match_info['id'])
+
+
+async def _write(resource, service_fn, *, status):
+    v = cerberus.Validator({
+        'id': {'type': 'integer', 'readonly': True},
+        'title': {'type': 'string'},
+        'content': {'type': 'string', 'required': True},
+        'syntax': {'type': 'string'},
+        'tags': {'type': 'list',
+                 'schema': {'type': 'string', 'regex': '[\w_-]+'}},
+        'created_at': {'type': 'datetime', 'readonly': True},
+        'updated_at': {'type': 'datetime', 'readonly': True},
+    })
+
+    snippet = await resource.read_request()
+    conf = resource.request.app['conf']
+    syntaxes = conf.getlist('snippet', 'syntaxes', fallback=None)
+
+    # If 'snippet:syntaxes' option is not empty, we need to ensure that
+    # only specified syntaxes are allowed.
+    if syntaxes:
+        v.schema['syntax']['allowed'] = syntaxes
+
+    # In case of PATCH required attributes must become optional, since
+    # the operation updates the entity partially and we assume all
+    # constraints are satisfied in the database.
+    is_patch = resource.request.method.lower() == 'patch'
+
+    if not v.validate(snippet, update=is_patch):
+        error = cerberus_errors_to_str(v.errors)
+        return resource.make_response({'message': '%s.' % error}, status=400)
+
+    try:
+        written = await service_fn(snippet)
+
+    except InvalidId as exc:
+        return resource.make_response({'message': str(exc)}, status=400)
+    except exceptions.SnippetNotFound as exc:
+        return resource.make_response({'message': str(exc)}, status=404)
+
+    return resource.make_response(written, status=status)
+
+
+async def _read(resource, service_fn, *, status):
+    try:
+        read = await service_fn(_get_id(resource))
+
+    except InvalidId as exc:
+        return resource.make_response({'message': str(exc)}, status=400)
+    except exceptions.SnippetNotFound as exc:
+        return resource.make_response({'message': str(exc)}, status=404)
+
+    return resource.make_response(read, status=status)
 
 
 @endpoint('/snippets/{id}', '1.0')
 class Snippet(resource.Resource):
 
+    def checkpermissions(fn):
+        @functools.wraps(fn)
+        async def _wrapper(self, *args, **kwargs):
+            # So far there's no way to check user's permissions as we don't
+            # track users and snippets' owners. However, we do support methods
+            # to change the snippet and we need to ensure it's not exposed to
+            # public but can be tested. That's why we check for a fake flag in
+            # conf object that can be set in tests in order to test existing
+            # functionality.
+            conf = self.request.app['conf']
+            if not conf.getboolean('test', 'sudo', fallback=False):
+                return self.make_response(
+                    {
+                        'message': 'Not yet. :)'
+                    },
+                    status=403)
+            return await fn(self, *args, **kwargs)
+        return _wrapper
+
     async def get(self):
-        return await self._run(services.Snippet(self.db).get_one, 200)
+        return await _read(self, services.Snippet(self.db).get_one, status=200)
 
+    @checkpermissions
     async def delete(self):
-        # TODO: only authorized owners can remove their snippets
-        return await self._run(services.Snippet(self.db).delete, 204)
+        return await _read(self, services.Snippet(self.db).delete, status=204)
 
-    async def _run(self, service_fn, status):
-        v = cerberus.Validator({
-            'id': {'type': 'integer', 'min': 1, 'coerce': try_int},
-        })
+    @checkpermissions
+    async def put(self):
+        async def service_fn(snippet):
+            snippet['id'] = _get_id(self)
+            return await services.Snippet(self.db).replace(snippet)
 
-        if not v.validate(dict(self.request.match_info)):
-            error = '%s.' % cerberus_errors_to_str(v.errors)
-            return self.make_response({'message': error}, status=400)
+        return await _write(self, service_fn, status=200)
 
-        try:
-            rv = await service_fn(int(self.request.match_info['id']))
-        except exceptions.SnippetNotFound as exc:
-            return self.make_response({'message': str(exc)}, status=404)
+    @checkpermissions
+    async def patch(self):
+        async def service_fn(snippet):
+            snippet['id'] = _get_id(self)
+            return await services.Snippet(self.db).update(snippet)
 
-        return self.make_response(rv, status)
+        return await _write(self, service_fn, status=200)
 
 
 @endpoint('/snippets', '1.0')
@@ -99,25 +177,4 @@ class Snippets(resource.Resource):
         return self.make_response(snippets, status=200)
 
     async def post(self):
-        snippet = await self.read_request()
-
-        conf = self.request.app['conf']
-        syntaxes = conf.getlist('snippet', 'syntaxes', fallback=None)
-        v = cerberus.Validator(_schema)
-
-        if not v.validate(snippet):
-            error = cerberus_errors_to_str(v.errors)
-        elif syntaxes and snippet.get('syntax') not in syntaxes:
-            error = '`syntax` - invalid value'
-        else:
-            error = None
-
-        if error:
-            return self.make_response(
-                {
-                    'message': 'Cannot create a new snippet, passed data are '
-                               'incorrect. Found issues: %s.' % error
-                }, status=400)
-
-        snippet = await services.Snippet(self.db).create(snippet)
-        return self.make_response(snippet, status=201)
+        return await _write(self, services.Snippet(self.db).create, status=201)


### PR DESCRIPTION
PUT & PATCH HTTP methods are intended to change snippet attributes by
authenticated owners. This is a first step towards changesets.

The difference between PUT and PATCH is in the following:

* PUT replaces snippet entity in the database. Any missed attributes will
  be reset to default.

* PATCH updates entity in the database. Any missed attributes will be
  kept untouched.