### PR TITLE
Minor enhancements in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ deps =
     pytest-cov
     flake8
 commands =
-    python setup.py check --strict
-    flake8 xsnippet_api/ tests/
-    py.test tests/ --cov --cov-append
+    {envpython} setup.py check --strict
+    {envpython} -m flake8 {posargs:.}
+    {envpython} -m pytest {posargs:.} --cov --cov-append --strict
 
 [testenv:openapi]
 usedevelop = false


### PR DESCRIPTION
May God and @malor forgive me, but I made several unrelated changes
to `tox.ini` in one commit. Why? I think changing three lines in
several commits including the very one that will be changed in each
of them, rather a silly idea; so there we are.

The commit accommodates the following changes:

 * `py.test` executable is deprecated in favor of `pytest`, however,
   it was decided to use Python module notation instead as it doesn't
   rely on binary name.

 * Both `pytest` and `flake8` might be available globally on the machine
   (e.g. pytest on Travis CI), so let's use `{envpython}` notation
   instead of binary names in order to avoid ambiguous situations.

 * The `--strict` flag is passed to `pytest` to treat warnings as
   errors.

 * Both `pytest` and `flake8` run for the whole project instead of
   just xsnippet_api/ and tests/ folders; this allows us to have some
   tests inside contrib/ directory (if any).