### PR TITLE
docs: produce API docs from OpenAPI spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - python: 3.6
       env: TOXENV=py36
     - env: TOXENV=openapi
+    - python: 3.6
+      env: TOXENV=docs
 
 services:
   - docker

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,29 @@
+import os
+import pkg_resources
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+project = 'XSnippet API'
+copyright = '2017, The XSnippet Team'
+release = pkg_resources.get_distribution('xsnippet-api').version
+version = '.'.join(release.split('.')[:2])
+extensions = [
+    'sphinxcontrib.redoc',
+]
+source_suffix = '.rst'
+master_doc = 'index'
+exclude_patterns = ['_build']
+pygments_style = 'sphinx'
+redoc = [
+    {
+        'name': project,
+        'page': 'api/index',
+        'spec': os.path.join(here, '..', 'contrib', 'openapi', 'spec.yml'),
+    },
+]
+
+if not os.environ.get('READTHEDOCS') == 'True':
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,4 @@
+XSnippet API
+============
+
+At the time we do not have docs other than `API docs <api>`_.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinxcontrib-redoc >= 1.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,12 @@ usedevelop = false
 deps = flex
 commands =
     swagger-flex -s contrib/openapi/spec.yml
+
+[testenv:docs]
+basepython = python3
+deps =
+    sphinx
+    sphinx_rtd_theme
+    -rdocs/requirements.txt
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/


### PR DESCRIPTION
This commit introduce a very basic Sphinx skeleton that do nothing but
renders OpenAPI spec by means of `sphinxcontrib-redoc` extension.