### PR TITLE
Fix the failing tests due to new release of aiohttp

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -198,7 +198,7 @@ class AIOTestApp(object):
 
         # we've got to wait until client connections are properly closed
         await self._app.shutdown()
-        await self._handler.finish_connections()
+        await self._handler.shutdown()
         await self._app.cleanup()
 
         self._server = None


### PR DESCRIPTION
Apparently, `Server.finish_connections` had been deprecated since
aiohttp version 1.2 and was eventually removed. As we depend on
1.2+, we can safely use the replacement - `Server.shutdown`.