### PR TITLE
Add support for filtering by title and tag

### DIFF
--- a/contrib/openapi/spec.yml
+++ b/contrib/openapi/spec.yml
@@ -71,6 +71,18 @@ paths:
         Returned snippets are sorted in reversed chronological order, so
         most recent ones appear first.
       parameters:
+        - name: title
+          in: query
+          type: string
+          description: |
+            If passed, only the snippets with titles starting with the given
+            string will be returned.
+        - name: tag
+          in: query
+          type: string
+          description: |
+            If passed, only the snippets that have the given string tag will
+            be returned.
         - name: marker
           in: query
           type: integer

--- a/xsnippet_api/database.py
+++ b/xsnippet_api/database.py
@@ -60,6 +60,16 @@ async def setup(app):
         db.snippets.create_index('author_id',
                                  name='author_idx',
                                  background=True),
+        db.snippets.create_index('title',
+                                 name='title_idx',
+                                 # create a partial index to skip null values -
+                                 # this is supposed to make the index smaller,
+                                 # so that there is a higher chance it's kept
+                                 # in the main memory
+                                 partialFilterExpression={
+                                    'title': {'$type': 'string'}
+                                 },
+                                 background=True),
         db.snippets.create_index('tags',
                                  name='tags_idx',
                                  background=True),

--- a/xsnippet_api/resources/snippets.py
+++ b/xsnippet_api/resources/snippets.py
@@ -72,6 +72,14 @@ class Snippets(resource.Resource):
                 'min': 1,
                 'coerce': try_int,
             },
+            'title': {
+                'type': 'string',
+                'empty': False,
+            },
+            'tag': {
+                'type': 'string',
+                'regex': '[\w_-]+',
+            }
         })
 
         if not v.validate(dict(self.request.GET)):
@@ -80,6 +88,8 @@ class Snippets(resource.Resource):
 
         try:
             snippets = await services.Snippet(self.db).get(
+                title=self.request.GET.get('title'),
+                tag=self.request.GET.get('tag'),
                 # It's safe to have type cast here since those query parameters
                 # are guaranteed to be integer, thanks to validation above.
                 limit=int(self.request.GET.get('limit', 0)),


### PR DESCRIPTION
It's now possible to pass additional query parameters `title` and
`tag`, so that only the snippets that have corresponding attribute
values are returned, e.g.:

    GET /snippets?title=foo&tag=bar

Filtering by title is implemented by searching for all the matches,
that start with the given string (both for efficiency and
feature-parity reasons).