### PR TITLE
Add a tox env for building a Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # Various shit from the OS itself
 .DS_Store
+
+# building of Docker images
+.docker

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,13 @@ deps =
     -rdocs/requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/
+
+[testenv:docker-build]
+usedevelop = false
+basepython = python3
+deps =
+whitelist_externals = bash
+commands =
+    bash -c "docker build \
+                -t xsnippet/xsnippet-api:{posargs:$(git status | grep 'working tree clean' >/dev/null && git rev-parse --short HEAD || echo -n wip)} \
+                -f contrib/docker/Dockerfile ."


### PR DESCRIPTION
Build a new image using the short commit id as a tag:

    $ tox -e docker-build

Note, that if the working directory contains uncommitted changes,
a special `wip` tag will be used instead of the commit id.

Build a new image with a given tag:

    $ tox -e docker-build -- latest