### PR TITLE
Add a basic ansible playbook for deployment

### DIFF
--- a/contrib/ansible/deploy.yaml
+++ b/contrib/ansible/deploy.yaml
@@ -1,0 +1,68 @@
+---
+- hosts: xsnippet
+  tasks:
+    - name: ensure Python 2 is installed
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+  gather_facts: false
+
+- hosts: xsnippet
+  vars:
+    xsnippet_image: xsnippet/xsnippet-api:latest
+  tasks:
+    - name: update apt cache (if needed)
+      apt: update_cache=yes cache_valid_time=3600
+
+    - name: install essential packages
+      apt: "name={{ item }} state=latest"
+      with_items:
+        - apt-transport-https
+        - ca-certificates
+
+    - name: add Docker gpg key
+      apt_key:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: present
+
+    - name: add Docker packages repo
+      apt_repository:
+        repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+      register: newrepo
+
+    - name: update apt cache (if needed)
+      apt: update_cache=yes
+      when: newrepo.changed
+
+    - name: install the latest Docker
+      apt: name=docker-ce state=latest
+
+    - name: initialize Docker Swarm
+      shell: "docker swarm init --advertise-addr 127.0.0.1 || docker stack ls"
+      register: init_result
+      changed_when: "'This node is already part of a swarm' not in init_result.stderr"
+
+    - name: create xsnippet user
+      user:
+        name: xsnippet
+        createhome: yes
+
+    - name: prepare the config file
+      template:
+        src: xsnippet-api.conf.j2
+        dest: "/home/xsnippet/xsnippet-api.conf"
+        mode: 0600
+        owner: xsnippet
+        group: xsnippet
+
+    - name: prepare the Docker stack config
+      template:
+        src: docker-compose.yml.j2
+        dest: "/home/xsnippet/docker-compose.yml"
+        mode: 0600
+        owner: xsnippet
+        group: xsnippet
+
+    - name: create or update a Docker Swarm stack
+      command: "docker stack deploy -c docker-compose.yml xsnippet"
+      args:
+        chdir: "/home/xsnippet"

--- a/contrib/ansible/docker-compose.yml.j2
+++ b/contrib/ansible/docker-compose.yml.j2
@@ -1,0 +1,38 @@
+version: "3.3"
+services:
+  db:
+    image: mongo:3
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - db_state:/data/db
+    networks:
+      - default
+
+  api:
+    image: {{ xsnippet_image }}
+    configs:
+      - source: api_config
+        target: /etc/xsnippet-api.conf
+        mode: 0600
+    deploy:
+      replicas: 2
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - db
+    ports:
+      - "80:8000"
+    networks:
+      - default
+networks:
+  default:
+
+volumes:
+  db_state:
+
+configs:
+  api_config:
+    file: ./xsnippet-api.conf

--- a/contrib/ansible/xsnippet-api.conf.j2
+++ b/contrib/ansible/xsnippet-api.conf.j2
@@ -1,0 +1,47 @@
+[server]
+
+; IP ADDRESS TO LISTEN ON
+;
+; By default, only localhost interface is used for listening. That's
+; why no requests from outer world will be handled. If you want to
+; accept any incoming request on any interface, please change that
+; value to '0.0.0.0'.
+host = 0.0.0.0
+
+; PORT TO LISTEN ON
+;
+; In production you probably will choose a default HTTP port - '80'.
+; If you want to pick any random free port, just pass '0'.
+port = 8000
+
+
+[database]
+
+; DATABASE CONNECTION URI
+;
+; Supported backends: MongoDB only
+connection = mongodb://db:27017/xsnippet
+
+
+[snippet]
+
+; LIST OF ALLOWED SYNTAXES
+;
+; Set constraint on 'snippet.syntax' property. Each syntax should come
+; on separate line. E.g:
+;
+;    syntaxes =
+;        cpp
+;        python
+;        javascript
+;
+; By default, constraint is not defined so any syntax is accepted.
+
+
+[auth]
+
+; SECRET KEY TO BE USED FOR VALIDATION OF SIGNED TOKENS
+;
+; If not set, it will be generated automatically for this run of application.
+; Set the value explicitly, so that it's preserved between runs.
+secret =


### PR DESCRIPTION
The playbook allows to deploy xsnippet-api on a clean Ubuntu Xenial
machine, e.g.:

    $ ansible-playbook -u user \
                       -e xsnippet_image=xsnippet/xsnippet-api:latest \
        contrib/ansible/deploy.yaml

`xsnippet_image` variable can be used to specify the exact Docker
image, that should be deployed (it is expected, that the image has
already been built and pushed to the registry).

The playbook also deploys xsnippet-api dependencies like MongoDB.