### PR TITLE
Use py3, openapi and docs as default Tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py35, py36, openapi
+envlist = py3, openapi, docs
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
There's no need to run tox for few Python 3.x versions by default
because most of the time machines don't have them installed at the
same time. For CI purposes, we explicitly pass Python versions
we want to run anyway.

Also, let's check docs by default. :)