### PR TITLE
Add GET /syntaxes endpoint

### DIFF
--- a/contrib/ansible/xsnippet-api.conf.j2
+++ b/contrib/ansible/xsnippet-api.conf.j2
@@ -35,7 +35,161 @@ connection = mongodb://db:27017/xsnippet
 ;        python
 ;        javascript
 ;
-; By default, constraint is not defined so any syntax is accepted.
+
+syntaxes =
+    APL
+    ASN.1
+    ASP.NET
+    Asterisk
+    Brainfuck
+    C
+    C#
+    C++
+    CMake
+    CQL
+    CSS
+    Clojure
+    ClojureScript
+    Closure Stylesheets (GSS)
+    Cobol
+    CoffeeScript
+    Common Lisp
+    Crystal
+    Cypher
+    Cython
+    D
+    DTD
+    Dart
+    Django
+    Dockerfile
+    Dylan
+    EBNF
+    ECL
+    Eiffel
+    Elm
+    Embedded Javascript
+    Embedded Ruby
+    Erlang
+    Esper
+    F#
+    FCL
+    Factor
+    Forth
+    Fortran
+    Gas
+    Gherkin
+    GitHub Flavored Markdown
+    Go
+    Groovy
+    HAML
+    HTML
+    HTTP
+    HXML
+    Haskell
+    Haskell (Literate)
+    Haxe
+    IDL
+    JSON
+    JSON-LD
+    JSX
+    Java
+    Java Server Pages
+    JavaScript
+    Jinja2
+    Julia
+    Kotlin
+    LESS
+    LaTeX
+    LiveScript
+    Lua
+    MS SQL
+    MUMPS
+    MariaDB SQL
+    Markdown
+    Mathematica
+    Modelica
+    MySQL
+    NSIS
+    NTriples
+    Nginx
+    OCaml
+    Objective-C
+    Octave
+    Oz
+    PEG.js
+    PGP
+    PHP
+    PLSQL
+    Pascal
+    Perl
+    Pig
+    Plain Text
+    PowerShell
+    Properties files
+    ProtoBuf
+    Pug
+    Puppet
+    Python
+    Q
+    R
+    RPM Changes
+    RPM Spec
+    Ruby
+    Rust
+    SAS
+    SCSS
+    SPARQL
+    SQL
+    SQLite
+    Sass
+    Scala
+    Scheme
+    Shell
+    Sieve
+    Slim
+    Smalltalk
+    Smarty
+    Solr
+    Soy
+    Spreadsheet
+    Squirrel
+    Stylus
+    Swift
+    SystemVerilog
+    TOML
+    TTCN
+    TTCN_CFG
+    Tcl
+    Textile
+    TiddlyWiki
+    Tiki wiki
+    Tornado
+    Turtle
+    Twig
+    TypeScript
+    TypeScript-JSX
+    VB.NET
+    VBScript
+    VHDL
+    Velocity
+    Verilog
+    Vue.js Component
+    Web IDL
+    XML
+    XQuery
+    YAML
+    Yacas
+    Z80
+    diff
+    edn
+    mIRC
+    mbox
+    mscgen
+    msgenny
+    reStructuredText
+    sTeX
+    troff
+    xu
 
 
 [auth]

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -1,0 +1,27 @@
+import pkg_resources
+import pytest
+
+from xsnippet.api.application import create_app
+from xsnippet.api.conf import get_conf
+
+
+@pytest.fixture(scope='function')
+def appinstance():
+    conf = get_conf(
+        pkg_resources.resource_filename('xsnippet.api', 'default.conf'))
+    conf['auth'] = {'secret': 'SWORDFISH'}
+    return create_app(conf)
+
+
+@pytest.fixture(scope='function')
+async def db(testapp, appinstance):
+    # It's important to depend on testapp, as it starts the app and we create
+    # DB connection during startup.
+    return appinstance['db']
+
+
+@pytest.fixture(scope='function')
+async def testapp(request, loop, appinstance, test_client):
+    request.addfinalizer(
+        lambda: loop.run_until_complete(appinstance['db'].snippets.remove()))
+    return await test_client(appinstance)

--- a/tests/resources/test_snippets.py
+++ b/tests/resources/test_snippets.py
@@ -14,11 +14,7 @@ import json
 import datetime
 import operator
 
-import pkg_resources
 import pytest
-
-from xsnippet.api.application import create_app
-from xsnippet.api.conf import get_conf
 
 
 @pytest.fixture(scope='function')
@@ -44,28 +40,6 @@ def snippets():
             'updated_at': now,
         },
     ]
-
-
-@pytest.fixture(scope='function')
-def appinstance():
-    conf = get_conf(
-        pkg_resources.resource_filename('xsnippet.api', 'default.conf'))
-    conf['auth'] = {'secret': 'SWORDFISH'}
-    return create_app(conf)
-
-
-@pytest.fixture(scope='function')
-async def db(testapp, appinstance):
-    # It's important to depend on testapp, as it starts the app and we create
-    # DB connection during startup.
-    return appinstance['db']
-
-
-@pytest.fixture(scope='function')
-async def testapp(request, loop, appinstance, test_client):
-    request.addfinalizer(
-        lambda: loop.run_until_complete(appinstance['db'].snippets.remove()))
-    return await test_client(appinstance)
 
 
 def _compare_snippets(snippet_db, snippet_api):

--- a/tests/resources/test_syntaxes.py
+++ b/tests/resources/test_syntaxes.py
@@ -1,0 +1,78 @@
+"""
+    tests.resources.test_syntaxes
+    -----------------------------
+
+    Tests Syntaxes resource.
+
+    :copyright: (c) 2017 The XSnippet Team, see AUTHORS for details
+    :license: MIT, see LICENSE for details
+"""
+
+import pytest
+
+
+async def test_get_syntaxes_default_conf(testapp, appinstance):
+    resp = await testapp.get(
+        '/syntaxes',
+        headers={
+            'Accept': 'application/json',
+        }
+    )
+    assert resp.status == 200
+    assert await resp.json() == []
+
+
+@pytest.mark.parametrize('syntaxes,expected', [
+    ('', []),
+    ('clojure\npython', ['clojure', 'python'])
+])
+async def test_get_syntaxes_overriden_conf(testapp, appinstance,
+                                           syntaxes, expected):
+    appinstance['conf']['snippet']['syntaxes'] = syntaxes
+
+    resp = await testapp.get(
+        '/syntaxes',
+        headers={
+            'Accept': 'application/json',
+        }
+    )
+    assert resp.status == 200
+    assert await resp.json() == expected
+
+
+async def test_get_syntaxes_overriden_conf_no_syntaxes(testapp, appinstance):
+    appinstance['conf']['snippet'].pop('syntaxes', None)
+
+    resp = await testapp.get(
+        '/syntaxes',
+        headers={
+            'Accept': 'application/json',
+        }
+    )
+    assert resp.status == 200
+    assert await resp.json() == []
+
+
+@pytest.mark.parametrize('method', ['delete', 'post', 'put'])
+async def test_get_syntaxes_unsupported_method(testapp, method):
+    func = getattr(testapp, method)
+
+    resp = await func(
+        '/syntaxes',
+        headers={
+            'Accept': 'application/json',
+        }
+    )
+    assert resp.status == 405
+    assert 'Method Not Allowed' in await resp.text()
+
+
+async def test_get_syntaxes_unsupported_accept_type(testapp):
+    resp = await testapp.get(
+        '/syntaxes',
+        headers={
+            'Accept': 'application/xml',
+        }
+    )
+    assert resp.status == 406
+    assert 'Not Acceptable' in await resp.text()

--- a/xsnippet/api/resources/__init__.py
+++ b/xsnippet/api/resources/__init__.py
@@ -9,9 +9,11 @@
 """
 
 from .snippets import Snippet, Snippets
+from .syntaxes import Syntaxes
 
 
 __all__ = [
     'Snippet',
     'Snippets',
+    'Syntaxes'
 ]

--- a/xsnippet/api/resources/syntaxes.py
+++ b/xsnippet/api/resources/syntaxes.py
@@ -1,0 +1,23 @@
+"""
+    xsnippet.api.resources.syntaxes
+    -------------------------------
+
+    The module implements the resource, that allows to retrieve
+    the list of supported snippet syntaxes.
+
+    :copyright: (c) 2017 The XSnippet Team, see AUTHORS for details
+    :license: MIT, see LICENSE for details
+"""
+
+from .. import resource
+from ..application import endpoint
+
+
+@endpoint('/syntaxes', '1.0')
+class Syntaxes(resource.Resource):
+
+    async def get(self):
+        conf = self.request.app['conf']
+        syntaxes = conf.getlist('snippet', 'syntaxes', fallback=None) or []
+
+        return self.make_response(syntaxes, status=200)


### PR DESCRIPTION
This new endpoint allows to retrieve the list of supported snippet
syntaxes, that is defined in the config file. Modify the default
config to contain the list of syntaxes from the original XSnippet.

Put the test fixtures into conftest.py, so that they can be reused
in tests of different API resources.