### PR TITLE
Improve the efficiency of pagination

### DIFF
--- a/tests/resources/test_snippets.py
+++ b/tests/resources/test_snippets.py
@@ -445,8 +445,8 @@ async def test_data_model_indexes_exist(db):
         'title': {'$type': 'string'}
     }
     assert res['tags_idx']['key'] == [('tags', 1)]
-    assert res['updated_idx']['key'] == [('updated_at', -1)]
-    assert res['created_idx']['key'] == [('created_at', -1)]
+    assert res['updated_id_idx']['key'] == [('updated_at', -1), ('_id', -1)]
+    assert res['created_id_idx']['key'] == [('created_at', -1), ('_id', -1)]
 
 
 async def test_get_snippet(testapp, snippets, db):

--- a/xsnippet/api/database.py
+++ b/xsnippet/api/database.py
@@ -70,11 +70,18 @@ async def setup(app):
         db.snippets.create_index('tags',
                                  name='tags_idx',
                                  background=True),
-        db.snippets.create_index([('created_at', pymongo.DESCENDING)],
-                                 name='created_idx',
+        # use compound indexes for created_at / updated_at attributes for the
+        # sake of efficiency of pagination (we need an extra attribute to
+        # guarantee uniqueness of the sorting key value). Note, that these
+        # indexes still speed up prefix searches by created_at / updated_at
+        # when _id is not passed
+        db.snippets.create_index([('created_at', pymongo.DESCENDING),
+                                  ('_id', pymongo.DESCENDING)],
+                                 name='created_id_idx',
                                  background=True),
-        db.snippets.create_index([('updated_at', pymongo.DESCENDING)],
-                                 name='updated_idx',
+        db.snippets.create_index([('updated_at', pymongo.DESCENDING),
+                                  ('_id', pymongo.DESCENDING)],
+                                 name='updated_id_idx',
                                  background=True)
     ]
     return await asyncio.gather(*futures)

--- a/xsnippet/api/services/snippet.py
+++ b/xsnippet/api/services/snippet.py
@@ -68,13 +68,19 @@ class Snippet:
                     'points to a nonexistent snippet.')
 
             condition['$and'] = [
-                {'_id': {'$lt': specimen['id']}},
                 {'created_at': {'$lte': specimen['created_at']}},
+                {'_id': {'$lt': specimen['id']}},
             ]
 
+        # use a compound sorting key (created_at, _id) to avoid the ambiguity
+        # of equal created_at values (the only attribute of a snippet, that
+        # is guaranteed to be unique is the primary key - _id). There is a
+        # corresponding index on (created_at, _id), that ensures this operation
+        # can be performed efficiently (mongo does not need to sort documents
+        # at all - it just walks over the btree index in key descending order)
         query = self.db.snippets.find(condition).sort([
+            ('created_at', pymongo.DESCENDING),
             ('_id', pymongo.DESCENDING),
-            ('created_at', pymongo.DESCENDING)
         ])
         return await query.limit(limit).to_list(None)
 


### PR DESCRIPTION
The idea of marker-based pagination is that users pass the id of
the last item on a page that was returned in order to obtain the
next page.

On the db side we use the given id to find the "specimen" document
first and then use the "key" value (in our case we sort by value of
`created_at` attribute) to efficiently find the position of the
specimen document in a db index and then select the following `$limit`
documents (note, that we use btree indexes, which store all the keys
in some order, so the db just needs to follow btree node pointers -
no sorting is actually performed).

In order to avoid the ambiguity of multiple documents with the same
value of `created_at` attribute, we used a compoud sorting key -
`(_id, created_at)`. The problem with that was that we did not have
a compound index on those attributes, so Mongo query plan for a list
of snippets on some page looked like:

    1) scan the _id index to find keys where _id < $specimen_id
    2) fetch all the documents with _id's from 1) and also filter by
       created_at <= $specimen_created_at
    3) sort the fetched documents by (_id, created_at) in descending order
    4) take the first $limit documents and return them

^ the problem is that on the first pages (which are the viewed the most)
many documents would satisfy the conditions in 1) and 2), which is
exactly what we tried to avoid.

By having a compound index on `(created_at, _id)` and changing the
sorting key we get the following query plan:

    1) find the position of the specimen document in the compound index
    2) fetch the first $limit documents that that have (created_at, _id)
       less than (specimen_created_at, specimen_id)

I gave it a try on a test collection with 10k snippets and retrieved
the 20-item page that goes after the snippet with id equal to 9800
(i.e. 9800 are "older" than this one):

    1) w/o this change: 25ms, 9800 keys examined
    2) with this change: 1ms, 20 keys examined

Note, due to the nature of btree indexes we still use the very same
compound index for prefix queries by `created_at` only when `_id`
is not specified.