### PR TITLE
Add snippets filtering by syntax

### DIFF
--- a/xsnippet/api/resources/snippets.py
+++ b/xsnippet/api/resources/snippets.py
@@ -152,8 +152,19 @@ class Snippets(resource.Resource):
             'tag': {
                 'type': 'string',
                 'regex': '[\w_-]+',
-            }
+            },
+            'syntax': {
+                'type': 'string',
+            },
         })
+
+        conf = self.request.app['conf']
+        syntaxes = conf.getlist('snippet', 'syntaxes', fallback=None)
+
+        # If 'snippet:syntaxes' option is not empty, we need to ensure that
+        # only specified syntaxes are allowed.
+        if syntaxes:
+            v.schema['syntax']['allowed'] = syntaxes
 
         if not v.validate(dict(self.request.GET)):
             error = '%s.' % cerberus_errors_to_str(v.errors)
@@ -163,6 +174,7 @@ class Snippets(resource.Resource):
             snippets = await services.Snippet(self.db).get(
                 title=self.request.GET.get('title'),
                 tag=self.request.GET.get('tag'),
+                syntax=self.request.GET.get('syntax'),
                 # It's safe to have type cast here since those query parameters
                 # are guaranteed to be integer, thanks to validation above.
                 limit=int(self.request.GET.get('limit', 0)),

--- a/xsnippet/api/services/snippet.py
+++ b/xsnippet/api/services/snippet.py
@@ -52,13 +52,16 @@ class Snippet:
     async def replace(self, snippet):
         return await self.update(self._normalize(snippet))
 
-    async def get(self, *, title=None, tag=None, limit=100, marker=None):
+    async def get(self, *, title=None, tag=None, syntax=None, limit=100,
+                  marker=None):
         condition = {}
 
         if title is not None:
             condition['title'] = {'$regex': '^' + re.escape(title) + '.*'}
         if tag is not None:
             condition['tags'] = tag
+        if syntax is not None:
+            condition['syntax'] = syntax
 
         if marker:
             specimen = await self.db.snippets.find_one({'_id': marker})


### PR DESCRIPTION
In order to have feature parity with running xsnippet service we need
to provide a way to filter snippets by syntax, i.e. show only snippets
with a certain syntax.