### PR TITLE
Provide Link response header for pagination

### DIFF
--- a/tests/resources/test_snippets.py
+++ b/tests/resources/test_snippets.py
@@ -267,7 +267,7 @@ async def test_get_snippets_filter_by_title_and_tag_with_pagination(
         _compare_snippets(snippet_db, snippet_api)
     # Check that urls in Link preserve the additional query params
     expected_link1 = (
-        '<https://api.xsnippet.org/snippets?title=snippet+%231&tag=tag_a&limit=1>; rel="first", '  # noqa
+        '<https://api.xsnippet.org/snippets?title=snippet+%231&tag=tag_a&limit=1>; rel="first", '
         '<https://api.xsnippet.org/snippets?title=snippet+%231&tag=tag_a&limit=1&marker=3>; rel="next"'  # noqa
     )
     assert resp.headers['Link'] == expected_link1
@@ -285,8 +285,8 @@ async def test_get_snippets_filter_by_title_and_tag_with_pagination(
         _compare_snippets(snippet_db, snippet_api)
     # Check that urls in Link preserve the additional query params
     expected_link2 = (
-        '<https://api.xsnippet.org/snippets?title=snippet+%231&tag=tag_a&limit=1>; rel="first", '  # noqa
-        '<https://api.xsnippet.org/snippets?title=snippet+%231&tag=tag_a&limit=1>; rel="prev"'  # noqa
+        '<https://api.xsnippet.org/snippets?title=snippet+%231&tag=tag_a&limit=1>; rel="first", '
+        '<https://api.xsnippet.org/snippets?title=snippet+%231&tag=tag_a&limit=1>; rel="prev"'
     )
     assert resp.headers['Link'] == expected_link2
 
@@ -456,7 +456,7 @@ async def test_pagination_links_port_value_is_preserved_in_url(testapp):
             'X-Forwarded-Proto': 'https',
         }
     )
-    expected_link1 = '<https://api.xsnippet.org/snippets?limit=20>; rel="first"'  # noqa
+    expected_link1 = '<https://api.xsnippet.org/snippets?limit=20>; rel="first"'
     assert resp1.headers['Link'] == expected_link1
 
     # Port is passed explicitly
@@ -471,7 +471,7 @@ async def test_pagination_links_port_value_is_preserved_in_url(testapp):
             'X-Forwarded-Proto': 'https',
         }
     )
-    expected_link2 = '<https://api.xsnippet.org:443/snippets?limit=20>; rel="first"'  # noqa
+    expected_link2 = '<https://api.xsnippet.org:443/snippets?limit=20>; rel="first"'
     assert resp2.headers['Link'] == expected_link2
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,3 +35,6 @@ commands =
     bash -c "docker build \
                 -t xsnippet/xsnippet-api:{posargs:$(git status | grep 'working tree clean' >/dev/null && git rev-parse --short HEAD || echo -n wip)} \
                 -f contrib/docker/Dockerfile ."
+
+[flake8]
+max-line-length = 100

--- a/xsnippet/api/resource.py
+++ b/xsnippet/api/resource.py
@@ -58,7 +58,7 @@ class Resource(web.View):
         #: an application database alias to make code a bit readable
         self.db = self.request.app['db']
 
-    def make_response(self, data, status=200):
+    def make_response(self, data, headers=None, status=200):
         """Return an HTTP response object.
 
         The method serializes given data according to 'Accept' HTTP header,
@@ -66,6 +66,9 @@ class Resource(web.View):
 
         :param data: a data to be responded to client
         :type data: a serializable python object
+
+        :param headers: response headers to be returned to client
+        :type headers: dict
 
         :param status: an HTTP status code
         :type status: int
@@ -99,6 +102,7 @@ class Resource(web.View):
                 if fnmatch.fnmatch(supported_accept, accept):
                     return web.Response(
                         status=status,
+                        headers=headers,
                         content_type=supported_accept,
                         text=encode(data),
                     )

--- a/xsnippet/api/services/snippet.py
+++ b/xsnippet/api/services/snippet.py
@@ -97,7 +97,7 @@ class Snippet:
                     'points to a nonexistent snippet.')
 
             condition['$and'] = [
-                {'created_at': {filters['created_at']: specimen['created_at']}},  # noqa
+                {'created_at': {filters['created_at']: specimen['created_at']}},
                 {'_id': {filters['_id']: specimen['id']}},
             ]
 

--- a/xsnippet/api/services/snippet.py
+++ b/xsnippet/api/services/snippet.py
@@ -20,6 +20,29 @@ from .. import exceptions
 
 class Snippet:
 
+    _pagination = {
+        'forward': {
+            'filters': {
+                'created_at': '$lte',
+                '_id': '$lt',
+            },
+            'sort': {
+                'created_at': pymongo.DESCENDING,
+                '_id': pymongo.DESCENDING,
+            }
+        },
+        'backward': {
+            'filters': {
+                'created_at': '$gte',
+                '_id': '$gte',
+            },
+            'sort': {
+                'created_at': pymongo.ASCENDING,
+                '_id': pymongo.ASCENDING,
+            }
+        },
+    }
+
     def __init__(self, db):
         self.db = db
 
@@ -53,8 +76,11 @@ class Snippet:
         return await self.update(self._normalize(snippet))
 
     async def get(self, *, title=None, tag=None, syntax=None, limit=100,
-                  marker=None):
+                  marker=None, direction='forward'):
         condition = {}
+
+        sort = self._pagination[direction]['sort']
+        filters = self._pagination[direction]['filters']
 
         if title is not None:
             condition['title'] = {'$regex': '^' + re.escape(title) + '.*'}
@@ -71,8 +97,8 @@ class Snippet:
                     'points to a nonexistent snippet.')
 
             condition['$and'] = [
-                {'created_at': {'$lte': specimen['created_at']}},
-                {'_id': {'$lt': specimen['id']}},
+                {'created_at': {filters['created_at']: specimen['created_at']}},  # noqa
+                {'_id': {filters['_id']: specimen['id']}},
             ]
 
         # use a compound sorting key (created_at, _id) to avoid the ambiguity
@@ -80,10 +106,10 @@ class Snippet:
         # is guaranteed to be unique is the primary key - _id). There is a
         # corresponding index on (created_at, _id), that ensures this operation
         # can be performed efficiently (mongo does not need to sort documents
-        # at all - it just walks over the btree index in key descending order)
+        # at all - it just walks over the btree index in chosen order)
         query = self.db.snippets.find(condition).sort([
-            ('created_at', pymongo.DESCENDING),
-            ('_id', pymongo.DESCENDING),
+            ('created_at', sort['created_at']),
+            ('_id', sort['_id']),
         ])
         return await query.limit(limit).to_list(None)
 


### PR DESCRIPTION
When traversing the list of snippets page by page provide an additional
response header - Link - that contains the links to the previous and
the next page with the given value of limit (if such pages exist).

This follows the idea from:

    https://developer.github.com/v3/guides/traversing-with-pagination/

and

    https://tools.ietf.org/html/rfc5988

Hopefully, this will make using of pagination easier on the client
side.