### PR TITLE
Tweak the default acccess log format

### DIFF
--- a/xsnippet/api/__main__.py
+++ b/xsnippet/api/__main__.py
@@ -31,7 +31,9 @@ def main(args=sys.argv[1:]):
     web.run_app(
         create_app(conf),
         host=conf['server']['host'],
-        port=int(conf['server']['port']))
+        port=int(conf['server']['port']),
+        access_log_format=conf['server']['access_log_format']
+    )
 
 
 # let's make this module and xsnippet.api package to be executable, so

--- a/xsnippet/api/default.conf
+++ b/xsnippet/api/default.conf
@@ -15,6 +15,22 @@ host = 127.0.0.1
 port = 8000
 
 
+; ACCESS LOG FORMAT
+;
+; Note, that you have to use double % signs for escaping to work.
+;
+; %t  - datetime of the request
+; %a  - remote address
+; %r  - request status line
+; %s  - response status code
+; %b  - response size (bytes)
+; %Tf - request time (seconds)
+;
+; When deployed behind a reverse proxy, consider using the value of
+; headers like X-Real-IP or X-Forwarded-For instead of %a
+access_log_format = %%t %%a "%%r" %%s %%b %%{User-Agent}i" %%Tf
+
+
 [database]
 
 ; DATABASE CONNECTION URI


### PR DESCRIPTION
Make sure we've got the most important information like remote addr,
request status line, response code, response size, user agent and
request processing time, e.g:

```
[10/Jan/2018:21:00:14 +0000] 127.0.0.1 "GET /snippets?limit=5 HTTP/1.1" 200 233 curl/7.54.0" 0.030207
```

Note, that for production deploys behind a reverse-proxy this format
might be changed to use the HTTP headers like X-Real-IP or
X-Forwarded-For, if needed.

Partially closes #59