### PR TITLE
Make Resource class more "RESTful"

### DIFF
--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -19,11 +19,11 @@ from xsnippet.api import resource
 class _TestResource(resource.Resource):
 
     async def get(self):
-        return self.make_response({'who': 'batman'}, status=299)
+        return {'who': 'batman'}, 299
 
     async def post(self):
-        data = await self.read_request()
-        return self.make_response(data, status=298)
+        data = await self.request.get_data()
+        return data, 298
 
 
 @pytest.fixture(scope='function')

--- a/xsnippet/api/resources/syntaxes.py
+++ b/xsnippet/api/resources/syntaxes.py
@@ -16,6 +16,4 @@ class Syntaxes(resource.Resource):
 
     async def get(self):
         conf = self.request.app['conf']
-        syntaxes = conf.getlist('snippet', 'syntaxes', fallback=None) or []
-
-        return self.make_response(syntaxes, status=200)
+        return conf.getlist('snippet', 'syntaxes', fallback=[])


### PR DESCRIPTION
RESTfulness is weird word, I know, but the idea is to provide a base
class for purposes of building RESTful APIs. Gosh, it sounds complex
so here's what was changed:

 * Resource classes now return tuples instead of 'web.Response()' of
   the following format: (data, status_code, headers). Where both
   status_code and headers are optional and can be omitted. From now
   one, content negotiation is done by resource class implicitly.

 * Exception translation to proper HTTP response is done by Resource
   class either. So far domain exceptions are hardcoded now, but they
   will become optional very soon once I figure out the better API for
   parametrization. :)