### PR TITLE
Use explicitly set API version when not passed

### DIFF
--- a/xsnippet/api/application.py
+++ b/xsnippet/api/application.py
@@ -66,7 +66,7 @@ def create_app(conf):
         middlewares=[
             functools.partial(middlewares.auth.auth, conf['auth']),
         ],
-        router=router.VersionRouter({'1.0': v1}))
+        router=router.VersionRouter({'1.0': v1}, default='1.0'))
     app.on_startup.append(middlewares.auth.setup)
 
     # Attach settings to the application instance in order to make them


### PR DESCRIPTION
We used to fallback to latest stable API version when 'Api-Version'
header was omitted. While it made sense when we were using version
discovery mechanism, it makes a little sense now when all versions
are statically defined.

Since now it's more garbage and complication, not saying it doesn't
give us control on which version to serve by default, let's remove
this function now.