### PR TITLE
Rewrite "auth" middleware as new-style middleware

### DIFF
--- a/tests/middlewares/test_auth.py
+++ b/tests/middlewares/test_auth.py
@@ -8,8 +8,6 @@
     :license: MIT, see LICENSE for details
 """
 
-import functools
-
 import aiohttp.web as web
 import jose.jwt as jwt
 import pytest
@@ -20,7 +18,7 @@ from xsnippet.api import middlewares
 @pytest.fixture(scope='function')
 async def testapp(test_client):
     app = web.Application(middlewares=[
-        functools.partial(middlewares.auth.auth, {'secret': 'SWORDFISH'})
+        middlewares.auth.auth({'secret': 'SWORDFISH'}),
     ])
 
     async def handler(request):

--- a/xsnippet/api/application.py
+++ b/xsnippet/api/application.py
@@ -9,8 +9,6 @@
     :license: MIT, see LICENSE for details
 """
 
-import functools
-
 import aiohttp.web
 
 from . import database, router, middlewares, resources
@@ -64,7 +62,7 @@ def create_app(conf):
     # decorator, so they can be collected and passed to VersionRouter.
     app = aiohttp.web.Application(
         middlewares=[
-            functools.partial(middlewares.auth.auth, conf['auth']),
+            middlewares.auth.auth(conf['auth']),
         ],
         router=router.VersionRouter({'1.0': v1}))
     app.on_startup.append(middlewares.auth.setup)

--- a/xsnippet/api/middlewares/auth.py
+++ b/xsnippet/api/middlewares/auth.py
@@ -34,7 +34,7 @@ async def setup(app):
         conf['secret'] = secret
 
 
-async def auth(conf, app, next_handler):
+def auth(conf):
     """Authentication middleware.
 
     Performs user authentication by validating tokens passed in Authorization
@@ -46,9 +46,9 @@ async def auth(conf, app, next_handler):
     On failure 401 Unauthorized error is raised.
     """
 
-    secret = conf['secret']
-
-    async def auth_handler(request):
+    @web.middleware
+    async def _auth(request, handler):
+        secret = conf['secret']
         authorization = request.headers.get('Authorization')
 
         if authorization is not None:
@@ -68,6 +68,5 @@ async def auth(conf, app, next_handler):
         else:
             request['auth'] = None
 
-        return await next_handler(request)
-
-    return auth_handler
+        return await handler(request)
+    return _auth


### PR DESCRIPTION
Since aiohttp 2.3, old-style middlewares are deprecated [1] and hence
may be removed any time soon. Taking into account this fact, it'd be
better if rewrite our internal "auth" middleware to be a new-style
middleware as it may live longer than the former.

[1] https://docs.aiohttp.org/en/stable/web.html#old-style-middleware