### PR TITLE
Remove /app directory (sources) from Docker image

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -2,8 +2,7 @@ FROM python:latest
 MAINTAINER The XSnippet Team <dev@xsnippet.org>
 
 COPY . /app
-WORKDIR /app
-RUN pip install .
+RUN pip install /app && rm -rf /app
 
 ENV XSNIPPET_API_SETTINGS=/etc/xsnippet-api.conf
 


### PR DESCRIPTION
Since we install the app in the container by running `pip install` the
app will be copied over to some `/usr/lib/python3/site-packages` place.
That basically means we don't the sources in the container afterwards,
so why just not remove them to avoid ambiguousness about which code
is actually used to run the app?