### PR TITLE
Add .pytest_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pip-delete-this-directory.txt
 .tox/
 .coverage
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 


### PR DESCRIPTION
Recently pytest 3.4 was released where internal .cache directory has
been renamed into .pytest_cache. So we better extend .gitignore with
this name in order to prevent accidental committing temporary files.