### PR TITLE
Generate secret in main rather than in middleware

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -10,17 +10,6 @@
 
 import pytest
 
-from xsnippet.api import application
-from xsnippet.api.middlewares import auth
-
-
-async def test_auth_secret_is_generated_if_not_set(test_server, testconf, testdatabase):
-    testconf['auth'] = {'secret': ''}
-    app_instance = application.create_app(testconf, testdatabase)
-
-    await test_server(app_instance)
-    assert len(testconf['auth']['secret']) == auth.SECRET_LEN
-
 
 @pytest.mark.parametrize('name, value', [
     ('Accept', 'application/json'),

--- a/xsnippet/api/application.py
+++ b/xsnippet/api/application.py
@@ -70,8 +70,6 @@ def create_app(conf, db):
             middlewares.auth.auth(conf['auth']),
         ],
         router=router.VersionRouter({'1.0': v1}, default='1.0'))
-
-    app.on_startup.append(functools.partial(middlewares.auth.setup, conf=conf))
     app.on_startup.append(functools.partial(database.setup, db=db))
 
     # We need to respond with Vary header time to time in order to avoid

--- a/xsnippet/api/middlewares/auth.py
+++ b/xsnippet/api/middlewares/auth.py
@@ -9,27 +9,8 @@
     :license: MIT, see LICENSE for details
 """
 
-import random
-import string
-
 import aiohttp.web as web
 import jose.jwt as jwt
-
-
-SECRET_LEN = 64
-
-
-async def setup(app, conf):
-    """Perform middleware setup steps at application startup.
-
-    E.g. generate a temporary secret, if one was not set in conf explicitly."""
-
-    secret = conf['auth'].get('secret', '')
-    if not secret:
-        symbols = string.ascii_letters + string.digits
-        secret = ''.join(random.choice(symbols) for _ in range(SECRET_LEN))
-
-        conf['auth']['secret'] = secret
 
 
 def auth(conf):


### PR DESCRIPTION
There are couple of reasons of doing so but the main one is to make
middleware to be responsible for validating tokens only, moving
responsibility of getting secret (reading from config or generating one)
from middleware (as it's supposed to be as general as possible) to
consumers.

It'd make even more sense once we implement /auth endpoint that would be
responsible for issuing JWT tokens, meaning that the middleware is not
the only owner of authentication.