### PR TITLE
Return 400 Bad Request on malformed input JSON

### DIFF
--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -151,6 +151,16 @@ async def test_post_json(testapp, headers):
     assert await resp.json() == {'who': 'batman'}
 
 
+async def test_post_malformed_payload(testapp):
+    resp = await testapp.post('/test', data='malformed')
+
+    assert resp.status == 400
+    assert await resp.json() == {
+        'message': ('Malformed application/json payload: '
+                    'Expecting value: line 1 column 1 (char 0)'),
+    }
+
+
 async def test_post_unsupported_media_type(testapp):
     resp = await testapp.post(
         '/test',

--- a/xsnippet/api/resource.py
+++ b/xsnippet/api/resource.py
@@ -147,7 +147,13 @@ class Resource(web.View):
 
             if content_type in decoders:
                 decode = decoders[content_type]
-                return decode(await self.text())
+                text = await self.text()
+
+                try:
+                    return decode(text)
+                except Exception as exc:
+                    raise web.HTTPBadRequest(
+                        reason='Malformed %s payload: %s' % (content_type, exc))
 
             raise web.HTTPUnsupportedMediaType()
         return impl


### PR DESCRIPTION
Apparently we didn't have tests for malformed input payload and used to
fall with 500 Internal Server Error if input payload is not
de-serializable. o_O Luckily we found it early and from now on we will
return 400 Bad Request in this case.