### PR TITLE
Update Picobox to 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'motor >= 1.1',
         'python-jose >= 1.3.2',
         'werkzeug >= 0.11.4',
-        'picobox >= 1.1.0, < 2',
+        'picobox >= 2.0',
     ],
     tests_require=[
         'pytest >= 2.8.7',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,14 +39,13 @@ async def testapp(request, test_client, testconf, testdatabase):
     box.put('conf', testconf)
     box.put('database', testdatabase)
 
-    scope = picobox.push(box)
-    scope.__enter__()
+    picobox.push(box)
 
     # Python 3.5 does not support yield statement inside coroutines, hence we
     # cannot use yield fixtures here and are forced to use finalizers instead.
     # This is especially weird as Picobox provides convenient context manager
     # and no plain functions, that's why manual triggering is required.
-    request.addfinalizer(lambda: scope.__exit__(None, None, None))
+    request.addfinalizer(lambda: picobox.pop())
     return await test_client(
         create_app(),
 


### PR DESCRIPTION
Picobox 2.0 provides first citizens functions to `push()` and `pop()` boxes
to and from stack; no more weird `__enter__()` / `__exit__()` explicit calls
to context manager.