### PR TITLE
Move API routes into separate routes.py

### DIFF
--- a/xsnippet/api/application.py
+++ b/xsnippet/api/application.py
@@ -14,7 +14,7 @@ import functools
 import aiohttp.web
 import picobox
 
-from . import database, router, middlewares, resources
+from . import database, router, routes, middlewares
 
 
 async def _inject_vary_header(request, response):
@@ -59,9 +59,7 @@ def create_app(conf, db):
     """
 
     v1 = aiohttp.web.UrlDispatcher()
-    v1.add_route('*', '/snippets', resources.Snippets)
-    v1.add_route('*', '/snippets/{id}', resources.Snippet)
-    v1.add_route('*', '/syntaxes', resources.Syntaxes)
+    v1.add_routes(routes.v1)
 
     # We need to import all the resources in order to evaluate @endpoint
     # decorator, so they can be collected and passed to VersionRouter.

--- a/xsnippet/api/routes.py
+++ b/xsnippet/api/routes.py
@@ -1,0 +1,12 @@
+"""Routes of various API versions."""
+
+import aiohttp.web as web
+
+from . import resources
+
+
+v1 = [
+    web.route('*', '/snippets', resources.Snippets),
+    web.route('*', '/snippets/{id}', resources.Snippet),
+    web.route('*', '/syntaxes', resources.Syntaxes),
+]


### PR DESCRIPTION
Usually routes are shared between application instances, so there's no
real need to define them in-place in some application factory functions.
And if we move them into separate routes.py, we can make the project
easier for being explored by providing a single entry point (API) from
which everyone can traverse deep down to what they're looking for.