### PR TITLE
Use aiohttp_client fixture instead of test_client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ async def testdatabase(request, loop, testconf):
 
 
 @pytest.fixture(scope='function')
-async def testapp(request, test_client, testconf, testdatabase):
+async def testapp(request, aiohttp_client, testconf, testdatabase):
     box = picobox.Box()
     box.put('conf', testconf)
     box.put('database', testdatabase)
@@ -46,7 +46,7 @@ async def testapp(request, test_client, testconf, testdatabase):
     # This is especially weird as Picobox provides convenient context manager
     # and no plain functions, that's why manual triggering is required.
     request.addfinalizer(lambda: picobox.pop())
-    return await test_client(
+    return await aiohttp_client(
         create_app(),
 
         # If 'Content-Type' is not passed to HTTP request, aiohttp client will

--- a/tests/middlewares/test_auth.py
+++ b/tests/middlewares/test_auth.py
@@ -16,7 +16,7 @@ from xsnippet.api import middlewares
 
 
 @pytest.fixture(scope='function')
-async def testapp(test_client):
+async def testapp(aiohttp_client):
     app = web.Application(middlewares=[
         middlewares.auth.auth({'secret': 'SWORDFISH'}),
     ])
@@ -35,7 +35,7 @@ async def testapp(test_client):
         return web.Response(text='success')
     app.router.add_get('/success-no-token', handler)
 
-    return await test_client(app)
+    return await aiohttp_client(app)
 
 
 @pytest.mark.parametrize('token', [

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -55,7 +55,7 @@ class _TestDecodersResource(resource.Resource):
 
 
 @pytest.fixture(scope='function')
-async def testapp(test_client):
+async def testapp(aiohttp_client):
     app = web.Application()
     app.router.add_route('*', '/test', _TestResource)
     app.router.add_route('*', '/test-encoders', _TestEncodersResource)
@@ -66,7 +66,7 @@ async def testapp(test_client):
     # ridiculous because in case of RESTful API this is completely wrong
     # and APIs usually have their own defaults. So turn off this feature,
     # and do not set 'Content-Type' for us if it wasn't passed.
-    return await test_client(app, skip_auto_headers={'Content-Type'})
+    return await aiohttp_client(app, skip_auto_headers={'Content-Type'})
 
 
 @pytest.mark.parametrize('headers,', [

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -15,7 +15,7 @@ from xsnippet.api import router
 
 
 @pytest.fixture(scope='function')
-async def testapp(test_client):
+async def testapp(aiohttp_client):
     class _TestResource1(web.View):
         async def get(self):
             return web.Response(text='I am the night!')
@@ -39,7 +39,7 @@ async def testapp(test_client):
             default='2',
         )
     )
-    return await test_client(app)
+    return await aiohttp_client(app)
 
 
 async def test_version_1(testapp):


### PR DESCRIPTION
Since aiohttp 3.0 test_client fixture has been renamed into
aiohttp_client. While the old name still works for a while we better
keep up with the latest changes because it won't last forever and will
be removed in future versions.