### PR TITLE
Do not allow empty snippets

### DIFF
--- a/tests/resources/test_snippets.py
+++ b/tests/resources/test_snippets.py
@@ -566,6 +566,10 @@ async def test_post_snippet(testapp, testconf, snippet, rv):
         {'message': '`content` - must be of string type.'},
     ),
     (
+        {'content': ''},
+        {'message': '`content` - empty values not allowed.'},
+    ),
+    (
         {'content': 'test', 'tags': ['white space']},
         {'message': '`tags` - {0: ["value does not match regex \'[\\\\w_-]+\'"]}.'},
     ),
@@ -714,6 +718,10 @@ async def test_put_snippet_not_found(testapp):
         {'message': '`content` - must be of string type.'},
     ),
     (
+        {'content': ''},
+        {'message': '`content` - empty values not allowed.'},
+    ),
+    (
         {'content': 'test', 'tags': ['white space']},
         {'message': '`tags` - {0: ["value does not match regex \'[\\\\w_-]+\'"]}.'},
     ),
@@ -782,6 +790,10 @@ async def test_patch_snippet_not_found(testapp):
     (
         {'content': 42},
         {'message': '`content` - must be of string type.'},
+    ),
+    (
+        {'content': ''},
+        {'message': '`content` - empty values not allowed.'},
     ),
     (
         {'tags': ['white space']},

--- a/xsnippet/api/resources/snippets.py
+++ b/xsnippet/api/resources/snippets.py
@@ -36,7 +36,7 @@ async def _write(resource, service_fn, *, status, conf):
     v = cerberus.Validator({
         'id': {'type': 'integer', 'readonly': True},
         'title': {'type': 'string'},
-        'content': {'type': 'string', 'required': True},
+        'content': {'type': 'string', 'required': True, 'empty': False},
         'syntax': {'type': 'string'},
         'tags': {'type': 'list',
                  'schema': {'type': 'string', 'regex': '[\w_-]+'}},


### PR DESCRIPTION
Snippet with no content (i.e. content is "") is nonsense and noise, so
we better reject such snippets to be protected from noise and bots.