### PR TITLE
docker: use python:slim as a base to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM python:latest
-MAINTAINER The XSnippet Team <dev@xsnippet.org>
 
 COPY . /app
-RUN pip install /app && rm -rf /app
+WORKDIR /app
+RUN mkdir dist && pip wheel --wheel-dir dist .
 
+
+FROM python:slim
+MAINTAINER The XSnippet Team <dev@xsnippet.org>
+
+COPY --from=0 /app/dist /dist
+RUN ls -la /dist && pip install --no-cache-dir --no-index --find-links=/dist xsnippet-api && rm -rf /dist
 ENV XSNIPPET_API_SETTINGS=/etc/xsnippet-api.conf
 
 EXPOSE 8000


### PR DESCRIPTION
`python:latest` size is ~900 Mb, which sounds a lot for such a simple
app as xsnippet-api; we don't really need all that stuff. Use
`python:slim` image as a base instead, that is much smaller (~130 Mb).

As we still need some external tools like git to be pre-installed
in order to produce an xsnippet-api wheel, we use the new Docker
multi-stage builds feature: the first stage is responsible for
collecting all the necessary Python wheels (including xsnippet-api
itself); the second stage only copies the artifacts and installs
them to a slim image.

See Docker docs for details:

https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds