### PR TITLE
Drop support for reading of configuration from an INI-file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ MAINTAINER The XSnippet Team <dev@xsnippet.org>
 
 COPY --from=0 /app/dist /dist
 RUN ls -la /dist && pip install --no-cache-dir --no-index --find-links=/dist xsnippet-api && rm -rf /dist
-ENV XSNIPPET_API_SETTINGS=/etc/xsnippet-api.conf
 
 EXPOSE 8000
 ENTRYPOINT ["python", "-m", "xsnippet.api"]

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,7 +1,5 @@
 """Test xsnippet.api.conf module."""
 
-import textwrap
-
 from xsnippet.api.conf import get_conf
 
 
@@ -14,37 +12,6 @@ def test_get_conf(monkeypatch):
     monkeypatch.setenv('XSNIPPET_AUTH_SECRET', 'x$3cret')
 
     assert get_conf() == {
-        'SERVER_HOST': '1.2.3.4',
-        'SERVER_PORT': 1234,
-        'SERVER_ACCESS_LOG_FORMAT': '%x %y',
-        'DATABASE_CONNECTION_URI': 'mongodb://42.42.42.42/test',
-        'SNIPPET_SYNTAXES': ['foo', 'bar'],
-        'AUTH_SECRET': 'x$3cret',
-    }
-
-
-def test_get_conf_envvar(tmpdir, monkeypatch):
-    tmpdir.join('test.conf').write_text(
-        textwrap.dedent('''
-            [server]
-            host = 1.2.3.4
-            port = 1234
-            access_log_format = %%x %%y
-
-            [database]
-            connection = mongodb://42.42.42.42/test
-
-            [snippet]
-            syntaxes = foo
-                       bar
-
-            [auth]
-            secret = x$3cret
-        '''),
-        encoding='utf-8')
-    monkeypatch.setenv('XSNIPPET_TEST_CONF', tmpdir.join('test.conf').strpath)
-
-    assert get_conf(envvar='XSNIPPET_TEST_CONF') == {
         'SERVER_HOST': '1.2.3.4',
         'SERVER_PORT': 1234,
         'SERVER_ACCESS_LOG_FORMAT': '%x %y',

--- a/xsnippet/api/__main__.py
+++ b/xsnippet/api/__main__.py
@@ -28,7 +28,7 @@ def main(args=sys.argv[1:]):
     logging.basicConfig()
     logging.getLogger('aiohttp').setLevel(logging.INFO)
 
-    conf = get_conf(envvar='XSNIPPET_API_SETTINGS')
+    conf = get_conf()
     database = create_connection(conf)
 
     # The secret is required to sign issued JWT tokens, therefore it's crucial

--- a/xsnippet/api/conf.py
+++ b/xsnippet/api/conf.py
@@ -9,104 +9,68 @@
     :license: MIT, see LICENSE for details
 """
 
-import os
-import configparser
-
 import decouple
 
 
-def get_conf(envvar=None):
-    """Return one settings instance combines from different sources.
-
-    The idea that lies behind that function is to gather config settings
-    from different sources, including dynamic once pointed by passed
-    environment variable (usually production overrides).
-
-    :param envvar: an environment variable that points to additional config
-    :type envvar: str
+def get_conf():
+    """Return a settings instance based on configuration via env variables.
 
     :return: a configuration dictionary
     :rtype: :class:`dict`
     """
-    # TODO: Drop INI support and use configuration via environment vars only.
-
-    # Due to limitations of INI standard, there's no way to have an option
-    # which value is a list. Fortunately, since Python 3.5 we can provide
-    # so called converters: an additional functions to convert desired
-    # option to consumable format.
-    converters = {
-        'list': lambda v: list(filter(None, str.splitlines(v)))
-    }
-
-    conf = configparser.ConfigParser(converters=converters)
-    conf.read_dict({
-        'server': {
-            # IP ADDRESS TO LISTEN ON
-            #
-            # By default, only localhost interface is used for listening.
-            # That's why no requests from outer world will be handled. If you
-            # want to accept any incoming request on any interface, please
-            # change that value to '0.0.0.0'.
-            'host': decouple.config('XSNIPPET_SERVER_HOST', default='127.0.0.1'),
-
-            # PORT TO LISTEN ON
-            #
-            # In production you probably will choose a default HTTP port -
-            # '80'.  If you want to pick any random free port, just pass '0'.
-            'port': decouple.config('XSNIPPET_SERVER_PORT', default=8000, cast=int),
-
-            # ACCESS LOG FORMAT
-            #
-            # Note, that you have to use double % signs for escaping to work.
-            #
-            # %t  - datetime of the request
-            # %a  - remote address
-            # %r  - request status line
-            # %s  - response status code
-            # %b  - response size (bytes)
-            # %Tf - request time (seconds)
-            #
-            # When deployed behind a reverse proxy, consider using the value of
-            # headers like X-Real-IP or X-Forwarded-For instead of %a
-            'access_log_format': decouple.config(
-                'XSNIPPET_SERVER_ACCESS_LOG_FORMAT',
-                default='%t %a "%r" %s %b %{User-Agent}i" %Tf',
-                # ConfigParser supports string interpolation so we need to
-                # escape '%' before processing.
-                cast=lambda value: value.replace('%', '%%')),
-        },
-
-        'database': {
-            # DATABASE CONNECTION URI
-            #
-            # Supported backends: MongoDB only
-            'connection': decouple.config(
-                'XSNIPPET_DATABASE_CONNECTION_URI', default='mongodb://localhost:27017/xsnippet')
-        },
-
-        'snippet': {
-            'syntaxes': decouple.config(
-                'XSNIPPET_SNIPPET_SYNTAXES',
-                default='',
-                # Convert comma separated list retrieved from env variable
-                # to newline separated list ready to be processed by
-                # configparser.
-                cast=lambda value: value.replace(',', '\n')),
-        },
-
-        'auth': {
-            'secret': decouple.config('XSNIPPET_AUTH_SECRET', default=''),
-        },
-    })
-
-    if envvar is not None and envvar in os.environ:
-        conf.read(os.environ[envvar])
 
     return {
-        'SERVER_HOST': conf.get('server', 'host'),
-        'SERVER_PORT': conf.getint('server', 'port'),
-        'SERVER_ACCESS_LOG_FORMAT': conf.get('server', 'access_log_format'),
-        'DATABASE_CONNECTION_URI': conf.get('database', 'connection'),
-        'SNIPPET_SYNTAXES': conf.getlist('snippet', 'syntaxes'),
-        'AUTH_SECRET': conf.get('auth', 'secret'),
+        # IP ADDRESS TO LISTEN ON
+        #
+        # By default, only localhost interface is used for listening.
+        # That's why no requests from outer world will be handled. If you
+        # want to accept any incoming request on any interface, please
+        # change that value to '0.0.0.0'.
+        'SERVER_HOST': decouple.config(
+            'XSNIPPET_SERVER_HOST',
+            default='127.0.0.1'
+        ),
+        # PORT TO LISTEN ON
+        #
+        # In production you probably will choose a default HTTP port -
+        # '80'.  If you want to pick any random free port, just pass '0'.
+        'SERVER_PORT': decouple.config(
+            'XSNIPPET_SERVER_PORT',
+            default=8000,
+            cast=int
+        ),
+        # ACCESS LOG FORMAT
+        #
+        # Note, that you have to use double % signs for escaping to work.
+        #
+        # %t  - datetime of the request
+        # %a  - remote address
+        # %r  - request status line
+        # %s  - response status code
+        # %b  - response size (bytes)
+        # %Tf - request time (seconds)
+        #
+        # When deployed behind a reverse proxy, consider using the value of
+        # headers like X-Real-IP or X-Forwarded-For instead of %a
+        'SERVER_ACCESS_LOG_FORMAT': decouple.config(
+            'XSNIPPET_SERVER_ACCESS_LOG_FORMAT',
+            default='%t %a "%r" %s %b %{User-Agent}i" %Tf',
+        ),
+        # DATABASE CONNECTION URI
+        #
+        # Supported backends: MongoDB only
+        'DATABASE_CONNECTION_URI': decouple.config(
+            'XSNIPPET_DATABASE_CONNECTION_URI',
+            default='mongodb://localhost:27017/xsnippet'
+        ),
+        'SNIPPET_SYNTAXES': decouple.config(
+            'XSNIPPET_SNIPPET_SYNTAXES',
+            default='',
+            # parse a comma separated list retrieved from env variable
+            cast=lambda value: [v for v in value.split(',') if v]
+        ),
+        'AUTH_SECRET': decouple.config(
+            'XSNIPPET_AUTH_SECRET',
+            default=''
+        ),
     }


### PR DESCRIPTION
We only have a handful of settings and should be fine with using of
environment variables instead.