### PR TITLE
Bump aiohttp up to 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'pytest-runner',
     ],
     install_requires=[
-        'aiohttp >= 2.3.5, < 3',
+        'aiohttp >= 3.0.0, < 4',
         'cerberus >= 0.9.2',
         'motor >= 1.1',
         'python-jose >= 1.3.2',

--- a/xsnippet/api/application.py
+++ b/xsnippet/api/application.py
@@ -17,7 +17,7 @@ import picobox
 from . import database, router, middlewares, resources
 
 
-def _inject_vary_header(request, response):
+async def _inject_vary_header(request, response):
     """Inject a ``Vary`` HTTP header to response if needed.
 
     Depends on whether request has varies HTTP headers or not, we may or may

--- a/xsnippet/api/resources/snippets.py
+++ b/xsnippet/api/resources/snippets.py
@@ -197,17 +197,17 @@ class Snippets(resource.Resource):
         if syntaxes:
             v.schema['syntax']['allowed'] = syntaxes
 
-        if not v.validate(dict(self.request.GET)):
+        if not v.validate(dict(self.request.query)):
             error = '%s.' % cerberus_errors_to_str(v.errors)
             raise web.HTTPBadRequest(reason=error)
 
         # It's safe to have type cast here since those query parameters
         # are guaranteed to be integer, thanks to validation above.
-        limit = int(self.request.GET.get('limit', 20))
-        marker = int(self.request.GET.get('marker', 0))
-        title = self.request.GET.get('title')
-        tag = self.request.GET.get('tag')
-        syntax = self.request.GET.get('syntax')
+        limit = int(self.request.query.get('limit', 20))
+        marker = int(self.request.query.get('marker', 0))
+        title = self.request.query.get('title')
+        tag = self.request.query.get('tag')
+        syntax = self.request.query.get('syntax')
 
         # actual snippets to be returned
         current_page = await services.Snippet().get(


### PR DESCRIPTION
Every now and again, aiohttp continue to break XSnippet API. As we
try to keep up with bleeding edge technologies it's time to update the
code base and become compatible with latest aiohttp.

Most noticeable changes from our code base point of view are:

 * request.GET multi-dict is renamed to request.query
 * app.on_response_prepare signal now receives only coroutines
 * web.View() must implement __await__() instead of __iter__() now

It seems aiohttp tries to follow semantic version, so along with bumping
minimal supported version let's prevent potential failures by setting
upper constraint as well.