### PR TITLE
Add pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-byte-order-marker
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.7
+    hooks:
+      - id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
+python: 3.7
 
 matrix:
   include:
-    - python: 3.7
-      env: TOXENV=py37
-    - python: 3.7
-      env: TOXENV=openapi
-    - python: 3.7
-      env: TOXENV=docs
+    - env: TOXENV=pre-commit
+    - env: TOXENV=py37
+    - env: TOXENV=openapi
+    - env: TOXENV=docs
 
 services:
   - docker

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,13 @@ deps =
     flake8
 commands =
     {envpython} setup.py check --strict
-    {envpython} -m flake8 {posargs:.}
     {envpython} -m pytest {posargs:.} --cov --cov-append --strict
+
+[testenv:pre-commit]
+skip_install = true
+deps = pre-commit
+commands =
+    pre-commit run --all-files --show-diff-on-failure
 
 [testenv:openapi]
 basepython = python3


### PR DESCRIPTION
pre-commit is built to solve the hook issues. It is a multi-language
package manager for pre-commit hooks. You specify a list of hooks you
want and pre-commit manages the installation and execution of any hook
written in any language before every commit. pre-commit is specifically
designed to not require root access. If one of your developers doesn’t
have node installed but modifies a JavaScript file, pre-commit
automatically handles downloading and building node to run eslint
without root.

It's a common trend, at least among Python projects, to use this
software to run various lint checks.

https://pre-commit.com/