### PR TITLE
Use Black to format the code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,10 @@ repos:
     rev: 3.7.7
     hooks:
       - id: flake8
+        args: [--max-line-length=100]
+
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+        args: [--line-length=79]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,26 +4,25 @@ import pkg_resources
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-project = 'XSnippet API'
-copyright = '2017, The XSnippet Team'
-release = pkg_resources.get_distribution('xsnippet-api').version
-version = '.'.join(release.split('.')[:2])
-extensions = [
-    'sphinxcontrib.redoc',
-]
-source_suffix = '.rst'
-master_doc = 'index'
-exclude_patterns = ['_build']
-pygments_style = 'sphinx'
+project = "XSnippet API"
+copyright = "2017, The XSnippet Team"
+release = pkg_resources.get_distribution("xsnippet-api").version
+version = ".".join(release.split(".")[:2])
+extensions = ["sphinxcontrib.redoc"]
+source_suffix = ".rst"
+master_doc = "index"
+exclude_patterns = ["_build"]
+pygments_style = "sphinx"
 redoc = [
     {
-        'name': project,
-        'page': 'api/index',
-        'spec': os.path.join(here, '..', 'contrib', 'openapi', 'spec.yml'),
-    },
+        "name": project,
+        "page": "api/index",
+        "spec": os.path.join(here, "..", "contrib", "openapi", "spec.yml"),
+    }
 ]
 
-if not os.environ.get('READTHEDOCS') == 'True':
+if not os.environ.get("READTHEDOCS") == "True":
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from xsnippet.api import __license__ as license
 
 
 here = os.path.dirname(__file__)
-with open(os.path.join(here, 'README.rst'), 'r', encoding='utf-8') as f:
+with open(os.path.join(here, "README.rst"), "r", encoding="utf-8") as f:
     long_description = f.read()
 
 
@@ -17,59 +17,50 @@ with open(os.path.join(here, 'README.rst'), 'r', encoding='utf-8') as f:
 # packages so we need our own implementation that does. All this shit happened
 # due to desperate @ikalnytskyi's desire to use namespace packages.
 def find_packages(namespace):
-    return ['%s.%s' % (namespace, pkg) for pkg in _find_packages(namespace)]
+    return ["%s.%s" % (namespace, pkg) for pkg in _find_packages(namespace)]
 
 
 setup(
-    name='xsnippet-api',
+    name="xsnippet-api",
     version=version,
     description=(
-        'XSnippet is a simple web-service for sharing code snippets on the '
-        'Internet. Written for fun using bleeding edge technologies.'),
+        "XSnippet is a simple web-service for sharing code snippets on the "
+        "Internet. Written for fun using bleeding edge technologies."
+    ),
     long_description=long_description,
     license=license,
-    url='https://github.com/xsnippet/xsnippet-api/',
-    keywords='web-service restful-api snippet storage',
-    author='The XSnippet Team',
-    author_email='dev@xsnippet.org',
-    packages=find_packages('xsnippet'),
+    url="https://github.com/xsnippet/xsnippet-api/",
+    keywords="web-service restful-api snippet storage",
+    author="The XSnippet Team",
+    author_email="dev@xsnippet.org",
+    packages=find_packages("xsnippet"),
     include_package_data=True,
     zip_safe=False,
-    use_scm_version={
-        'root': here,
-    },
-    setup_requires=[
-        'pytest-runner',
-        'setuptools_scm',
-    ],
+    use_scm_version={"root": here},
+    setup_requires=["pytest-runner", "setuptools_scm"],
     install_requires=[
-        'aiohttp >= 3.0.0, < 4',
-        'cerberus >= 0.9.2',
-        'motor >= 2.0',
-        'python-jose >= 1.3.2',
-        'python-decouple >= 3.1',
-        'werkzeug >= 0.11.4',
-        'picobox >= 2.0',
+        "aiohttp >= 3.0.0, < 4",
+        "cerberus >= 0.9.2",
+        "motor >= 2.0",
+        "python-jose >= 1.3.2",
+        "python-decouple >= 3.1",
+        "werkzeug >= 0.11.4",
+        "picobox >= 2.0",
     ],
-    tests_require=[
-        'pytest >= 4.0.0',
-        'pytest-aiohttp >= 0.3.0',
-    ],
+    tests_require=["pytest >= 4.0.0", "pytest-aiohttp >= 0.3.0"],
     entry_points={
-        'console_scripts': [
-            'xsnippet-api = xsnippet.api.__main__:main',
-        ],
+        "console_scripts": ["xsnippet-api = xsnippet.api.__main__:main"]
     },
     classifiers=[
-        'Environment :: Web Environment',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Intended Audience :: End Users/Desktop',
-        'Intended Audience :: Information Technology',
-        'Topic :: Internet :: WWW/HTTP',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Environment :: Web Environment",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: Information Technology",
+        "Topic :: Internet :: WWW/HTTP",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,34 +10,38 @@ from xsnippet.api.conf import get_conf
 from xsnippet.api.database import create_connection
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def testconf():
     conf = get_conf()
-    conf['AUTH_SECRET'] = 'SWORDFISH'
+    conf["AUTH_SECRET"] = "SWORDFISH"
 
     # This flag exist to workaround permissions (which we currently lack of)
     # and test PUT/PATCH requests to the snippet. Once permissions are
     # implemented and the hack is removed from @checkpermissions decorator
     # in resources/snippets.py - this silly flag must be thrown away.
-    conf['_SUDO'] = True
+    conf["_SUDO"] = True
     return conf
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 async def testdatabase(request, loop, testconf):
     database = create_connection(testconf)
 
     # Python 3.5 does not support yield statement inside coroutines, hence we
     # cannot use yield fixtures here and are forced to use finalizers instead.
-    request.addfinalizer(lambda: loop.run_until_complete(database.client.drop_database(database)))
+    request.addfinalizer(
+        lambda: loop.run_until_complete(
+            database.client.drop_database(database)
+        )
+    )
     return database
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 async def testapp(request, aiohttp_client, testconf, testdatabase):
     box = picobox.Box()
-    box.put('conf', testconf)
-    box.put('database', testdatabase)
+    box.put("conf", testconf)
+    box.put("database", testdatabase)
 
     picobox.push(box)
 
@@ -48,13 +52,12 @@ async def testapp(request, aiohttp_client, testconf, testdatabase):
     request.addfinalizer(lambda: picobox.pop())
     return await aiohttp_client(
         create_app(),
-
         # If 'Content-Type' is not passed to HTTP request, aiohttp client will
         # report 'Content-Type: text/plain' to server. This is completely
         # ridiculous because in case of RESTful API this is completely wrong
         # and APIs usually have their own defaults. So turn off this feature,
         # and do not set 'Content-Type' for us if it wasn't passed.
-        skip_auto_headers={'Content-Type'},
+        skip_auto_headers={"Content-Type"},
     )
 
 

--- a/tests/resources/test_snippets.py
+++ b/tests/resources/test_snippets.py
@@ -23,9 +23,9 @@ class _pytest_link_header:
     def parse(link):
         rv = []
 
-        for link in link.split(','):
+        for link in link.split(","):
             link, params = cgi.parse_header(link)
-            link = link.lstrip('<').rstrip('>')
+            link = link.lstrip("<").rstrip(">")
 
             parts = urllib.parse.urlsplit(link)
             query = urllib.parse.parse_qs(parts.query)
@@ -35,7 +35,7 @@ class _pytest_link_header:
         # Dictionaries can't be compared by < and/or >, so we need to sort by
         # first three components (scheme, netloc, path) and optional "rel"
         # parameter because the latter usually uniquely defines a link.
-        return sorted(rv, key=lambda i: (i[-1].get('rel'), i[:3]))
+        return sorted(rv, key=lambda i: (i[-1].get("rel"), i[:3]))
 
     def __init__(self, link):
         self._link = link
@@ -47,30 +47,26 @@ class _pytest_link_header:
         return "'%s'" % self._link
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 async def snippets(testdatabase):
     snippets = [
         {
-            '_id': 1,
-            'title': 'snippet #1',
-            'changesets': [
-                {'content': 'def foo(): pass'},
-            ],
-            'syntax': 'python',
-            'tags': ['tag_a', 'tag_b'],
-            'created_at': datetime.datetime(2018, 1, 24, 22, 26, 35),
-            'updated_at': datetime.datetime(2018, 1, 24, 22, 26, 35),
+            "_id": 1,
+            "title": "snippet #1",
+            "changesets": [{"content": "def foo(): pass"}],
+            "syntax": "python",
+            "tags": ["tag_a", "tag_b"],
+            "created_at": datetime.datetime(2018, 1, 24, 22, 26, 35),
+            "updated_at": datetime.datetime(2018, 1, 24, 22, 26, 35),
         },
         {
-            '_id': 2,
-            'title': 'snippet #2',
-            'changesets': [
-                {'content': 'int do_something() {}'},
-            ],
-            'syntax': 'cpp',
-            'tags': ['tag_c'],
-            'created_at': datetime.datetime(2018, 1, 24, 22, 32, 7),
-            'updated_at': datetime.datetime(2018, 1, 24, 22, 32, 7),
+            "_id": 2,
+            "title": "snippet #2",
+            "changesets": [{"content": "int do_something() {}"}],
+            "syntax": "cpp",
+            "tags": ["tag_c"],
+            "created_at": datetime.datetime(2018, 1, 24, 22, 32, 7),
+            "updated_at": datetime.datetime(2018, 1, 24, 22, 32, 7),
         },
     ]
 
@@ -84,182 +80,231 @@ async def snippets(testdatabase):
         # One of SON manipulators we use converts 'id' into '_id' during
         # inserts/updates, and vice versa during reads. That's why we use
         # human readable 'id' and not '_id'.
-        snippet['id'] = id_
+        snippet["id"] = id_
 
     return snippets
 
 
 async def test_get_no_snippets(testapp):
-    resp = await testapp.get('/v1/snippets')
+    resp = await testapp.get("/v1/snippets")
 
     assert resp.status == 200
     assert await resp.json() == []
 
 
-@pytest.mark.parametrize('params, rv, link', [
-    (
-        {},
-        [{'id': 2,
-          'title': 'snippet #2',
-          'content': 'int do_something() {}',
-          'syntax': 'cpp',
-          'tags': ['tag_c'],
-          'created_at': '2018-01-24T22:32:07',
-          'updated_at': '2018-01-24T22:32:07'},
-         {'id': 1,
-          'title': 'snippet #1',
-          'content': 'def foo(): pass',
-          'syntax': 'python',
-          'tags': ['tag_a', 'tag_b'],
-          'created_at': '2018-01-24T22:26:35',
-          'updated_at': '2018-01-24T22:26:35'}],
-        ('<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
-    ),
-    (
-        {'title': 'snippet #1'},
-        [{'id': 1,
-          'title': 'snippet #1',
-          'content': 'def foo(): pass',
-          'syntax': 'python',
-          'tags': ['tag_a', 'tag_b'],
-          'created_at': '2018-01-24T22:26:35',
-          'updated_at': '2018-01-24T22:26:35'}],
-        ('<https://api.xsnippet.org/v1/snippets?title=snippet+%231&limit=20>; rel="first"'),
-    ),
-    (
-        {'title': 'nonexistent'},
-        [],
-        ('<https://api.xsnippet.org/v1/snippets?title=nonexistent&limit=20>; rel="first"'),
-    ),
-    (
-        {'tag': 'tag_c'},
-        [{'id': 2,
-          'title': 'snippet #2',
-          'content': 'int do_something() {}',
-          'syntax': 'cpp',
-          'tags': ['tag_c'],
-          'created_at': '2018-01-24T22:32:07',
-          'updated_at': '2018-01-24T22:32:07'}],
-        ('<https://api.xsnippet.org/v1/snippets?tag=tag_c&limit=20>; rel="first"'),
-    ),
-    (
-        {'tag': 'nonexistent'},
-        [],
-        ('<https://api.xsnippet.org/v1/snippets?tag=nonexistent&limit=20>; rel="first"'),
-    ),
-    (
-        {'syntax': 'python'},
-        [{'id': 1,
-          'title': 'snippet #1',
-          'content': 'def foo(): pass',
-          'syntax': 'python',
-          'tags': ['tag_a', 'tag_b'],
-          'created_at': '2018-01-24T22:26:35',
-          'updated_at': '2018-01-24T22:26:35'}],
-        ('<https://api.xsnippet.org/v1/snippets?syntax=python&limit=20>; rel="first"'),
-    ),
-    (
-        {'syntax': 'nonexistent'},
-        [],
-        ('<https://api.xsnippet.org/v1/snippets?syntax=nonexistent&limit=20>; rel="first"'),
-    ),
-    (
-        {'syntax': 'cpp', 'tag': 'tag_c'},
-        [{'id': 2,
-          'title': 'snippet #2',
-          'content': 'int do_something() {}',
-          'syntax': 'cpp',
-          'tags': ['tag_c'],
-          'created_at': '2018-01-24T22:32:07',
-          'updated_at': '2018-01-24T22:32:07'}],
-        ('<https://api.xsnippet.org/v1/snippets?syntax=cpp&tag=tag_c&limit=20>; rel="first"'),
-    ),
-    (
-        {'syntax': 'python', 'tag': 'tag_c'},
-        [],
-        ('<https://api.xsnippet.org/v1/snippets?syntax=python&tag=tag_c&limit=20>; rel="first"'),
-    ),
-    (
-        {'limit': 1},
-        [{'id': 2,
-          'title': 'snippet #2',
-          'content': 'int do_something() {}',
-          'syntax': 'cpp',
-          'tags': ['tag_c'],
-          'created_at': '2018-01-24T22:32:07',
-          'updated_at': '2018-01-24T22:32:07'}],
-        ('<https://api.xsnippet.org/v1/snippets?limit=1>; rel="first", '
-         '<https://api.xsnippet.org/v1/snippets?limit=1&marker=2>; rel="next"'),
-    ),
-    (
-        {'marker': 2},
-        [{'id': 1,
-          'title': 'snippet #1',
-          'content': 'def foo(): pass',
-          'syntax': 'python',
-          'tags': ['tag_a', 'tag_b'],
-          'created_at': '2018-01-24T22:26:35',
-          'updated_at': '2018-01-24T22:26:35'}],
-        ('<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
-    ),
-    (
-        {'marker': 1},
-        [],
-        ('<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
-    ),
-])
+@pytest.mark.parametrize(
+    "params, rv, link",
+    [
+        (
+            {},
+            [
+                {
+                    "id": 2,
+                    "title": "snippet #2",
+                    "content": "int do_something() {}",
+                    "syntax": "cpp",
+                    "tags": ["tag_c"],
+                    "created_at": "2018-01-24T22:32:07",
+                    "updated_at": "2018-01-24T22:32:07",
+                },
+                {
+                    "id": 1,
+                    "title": "snippet #1",
+                    "content": "def foo(): pass",
+                    "syntax": "python",
+                    "tags": ["tag_a", "tag_b"],
+                    "created_at": "2018-01-24T22:26:35",
+                    "updated_at": "2018-01-24T22:26:35",
+                },
+            ],
+            ('<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
+        ),
+        (
+            {"title": "snippet #1"},
+            [
+                {
+                    "id": 1,
+                    "title": "snippet #1",
+                    "content": "def foo(): pass",
+                    "syntax": "python",
+                    "tags": ["tag_a", "tag_b"],
+                    "created_at": "2018-01-24T22:26:35",
+                    "updated_at": "2018-01-24T22:26:35",
+                }
+            ],
+            (
+                '<https://api.xsnippet.org/v1/snippets?title=snippet+%231&limit=20>; rel="first"'
+            ),
+        ),
+        (
+            {"title": "nonexistent"},
+            [],
+            (
+                '<https://api.xsnippet.org/v1/snippets?title=nonexistent&limit=20>; rel="first"'
+            ),
+        ),
+        (
+            {"tag": "tag_c"},
+            [
+                {
+                    "id": 2,
+                    "title": "snippet #2",
+                    "content": "int do_something() {}",
+                    "syntax": "cpp",
+                    "tags": ["tag_c"],
+                    "created_at": "2018-01-24T22:32:07",
+                    "updated_at": "2018-01-24T22:32:07",
+                }
+            ],
+            (
+                '<https://api.xsnippet.org/v1/snippets?tag=tag_c&limit=20>; rel="first"'
+            ),
+        ),
+        (
+            {"tag": "nonexistent"},
+            [],
+            (
+                '<https://api.xsnippet.org/v1/snippets?tag=nonexistent&limit=20>; rel="first"'
+            ),
+        ),
+        (
+            {"syntax": "python"},
+            [
+                {
+                    "id": 1,
+                    "title": "snippet #1",
+                    "content": "def foo(): pass",
+                    "syntax": "python",
+                    "tags": ["tag_a", "tag_b"],
+                    "created_at": "2018-01-24T22:26:35",
+                    "updated_at": "2018-01-24T22:26:35",
+                }
+            ],
+            (
+                '<https://api.xsnippet.org/v1/snippets?syntax=python&limit=20>; rel="first"'
+            ),
+        ),
+        (
+            {"syntax": "nonexistent"},
+            [],
+            (
+                '<https://api.xsnippet.org/v1/snippets?syntax=nonexistent&limit=20>; rel="first"'
+            ),
+        ),
+        (
+            {"syntax": "cpp", "tag": "tag_c"},
+            [
+                {
+                    "id": 2,
+                    "title": "snippet #2",
+                    "content": "int do_something() {}",
+                    "syntax": "cpp",
+                    "tags": ["tag_c"],
+                    "created_at": "2018-01-24T22:32:07",
+                    "updated_at": "2018-01-24T22:32:07",
+                }
+            ],
+            (
+                '<https://api.xsnippet.org/v1/snippets?syntax=cpp&tag=tag_c&limit=20>; rel="first"'
+            ),
+        ),
+        (
+            {"syntax": "python", "tag": "tag_c"},
+            [],
+            (
+                "<https://api.xsnippet.org/v1/snippets?syntax=python&tag=tag_c&limit=20>; "
+                'rel="first"'
+            ),
+        ),
+        (
+            {"limit": 1},
+            [
+                {
+                    "id": 2,
+                    "title": "snippet #2",
+                    "content": "int do_something() {}",
+                    "syntax": "cpp",
+                    "tags": ["tag_c"],
+                    "created_at": "2018-01-24T22:32:07",
+                    "updated_at": "2018-01-24T22:32:07",
+                }
+            ],
+            (
+                '<https://api.xsnippet.org/v1/snippets?limit=1>; rel="first", '
+                '<https://api.xsnippet.org/v1/snippets?limit=1&marker=2>; rel="next"'
+            ),
+        ),
+        (
+            {"marker": 2},
+            [
+                {
+                    "id": 1,
+                    "title": "snippet #1",
+                    "content": "def foo(): pass",
+                    "syntax": "python",
+                    "tags": ["tag_a", "tag_b"],
+                    "created_at": "2018-01-24T22:26:35",
+                    "updated_at": "2018-01-24T22:26:35",
+                }
+            ],
+            ('<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
+        ),
+        (
+            {"marker": 1},
+            [],
+            ('<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
+        ),
+    ],
+)
 async def test_get_snippets(testapp, snippets, params, rv, link):
-    resp = await testapp.get('/v1/snippets', params=params, headers={
-        # Pass the additional headers, that are set by nginx in the production
-        # deployment, so that we ensure we generate the correct links for
-        # users.
-        'Host': 'api.xsnippet.org',
-        'X-Forwarded-Proto': 'https',
-    })
+    resp = await testapp.get(
+        "/v1/snippets",
+        params=params,
+        headers={
+            # Pass the additional headers, that are set by nginx in the production
+            # deployment, so that we ensure we generate the correct links for
+            # users.
+            "Host": "api.xsnippet.org",
+            "X-Forwarded-Proto": "https",
+        },
+    )
 
     assert resp.status == 200
     assert await resp.json() == rv
-    assert resp.headers['Link'] == _pytest_link_header(link)
+    assert resp.headers["Link"] == _pytest_link_header(link)
 
 
-@pytest.mark.parametrize('params, rv', [
-    (
-        {'title': ''},
-        {'message': '`title` - empty values not allowed.'},
-    ),
-    (
-        {'tag': ''},
-        {'message': "`tag` - value does not match regex '[\\w_-]+'."},
-    ),
-    (
-        {'tag': 'white space'},
-        {'message': "`tag` - value does not match regex '[\\w_-]+'."},
-    ),
-    (
-        {'syntax': ''},
-        {'message': '`syntax` - unallowed value .'},
-    ),
-    (
-        {'syntax': 'nonexistent'},
-        {'message': '`syntax` - unallowed value nonexistent.'},
-    ),
-    (
-        {'limit': 'deadbeef'},
-        {'message': '`limit` - must be of integer type.'},
-    ),
-    (
-        {'limit': '-1'},
-        {'message': '`limit` - min value is 1.'},
-    ),
-    (
-        {'deadbeef': 'joker'},
-        {'message': '`deadbeef` - unknown field.'},
-    ),
-])
-async def test_get_snippets_bad_request(testapp, testconf, snippets, params, rv):
-    testconf['SNIPPET_SYNTAXES'] = ['python', 'clojure']
+@pytest.mark.parametrize(
+    "params, rv",
+    [
+        ({"title": ""}, {"message": "`title` - empty values not allowed."}),
+        (
+            {"tag": ""},
+            {"message": "`tag` - value does not match regex '[\\w_-]+'."},
+        ),
+        (
+            {"tag": "white space"},
+            {"message": "`tag` - value does not match regex '[\\w_-]+'."},
+        ),
+        ({"syntax": ""}, {"message": "`syntax` - unallowed value ."}),
+        (
+            {"syntax": "nonexistent"},
+            {"message": "`syntax` - unallowed value nonexistent."},
+        ),
+        (
+            {"limit": "deadbeef"},
+            {"message": "`limit` - must be of integer type."},
+        ),
+        ({"limit": "-1"}, {"message": "`limit` - min value is 1."}),
+        ({"deadbeef": "joker"}, {"message": "`deadbeef` - unknown field."}),
+    ],
+)
+async def test_get_snippets_bad_request(
+    testapp, testconf, snippets, params, rv
+):
+    testconf["SNIPPET_SYNTAXES"] = ["python", "clojure"]
 
-    resp = await testapp.get('/v1/snippets', params=params)
+    resp = await testapp.get("/v1/snippets", params=params)
 
     assert resp.status == 400
     assert await resp.json() == rv
@@ -270,17 +315,21 @@ async def _get_next_page(testapp, limit=3, marker=0):
 
     params = {}
     if limit:
-        params['limit'] = limit
+        params["limit"] = limit
     if marker:
-        params['marker'] = marker
+        params["marker"] = marker
 
-    resp = await testapp.get('/v1/snippets', params=params, headers={
-        # Pass the additional headers, that are set by nginx in the production
-        # deployment, so that we ensure we generate the correct links for
-        # users.
-        'Host': 'api.xsnippet.org',
-        'X-Forwarded-Proto': 'https',
-    })
+    resp = await testapp.get(
+        "/v1/snippets",
+        params=params,
+        headers={
+            # Pass the additional headers, that are set by nginx in the production
+            # deployment, so that we ensure we generate the correct links for
+            # users.
+            "Host": "api.xsnippet.org",
+            "X-Forwarded-Proto": "https",
+        },
+    )
     assert resp.status == 200
     return resp
 
@@ -290,15 +339,13 @@ async def test_pagination_links(testapp, testdatabase):
     now = datetime.datetime.utcnow().replace(microsecond=0)
     snippets = [
         {
-            '_id': i + 1,
-            'title': 'snippet #%d' % (i + 1),
-            'changesets': [
-                {'content': '(println "Hello, World!")'},
-            ],
-            'syntax': 'clojure',
-            'tags': ['tag_b'],
-            'created_at': (now + datetime.timedelta(seconds=1)),
-            'updated_at': (now + datetime.timedelta(seconds=1)),
+            "_id": i + 1,
+            "title": "snippet #%d" % (i + 1),
+            "changesets": [{"content": '(println "Hello, World!")'}],
+            "syntax": "clojure",
+            "tags": ["tag_b"],
+            "created_at": (now + datetime.timedelta(seconds=1)),
+            "updated_at": (now + datetime.timedelta(seconds=1)),
         }
         for i in range(10)
     ]
@@ -311,8 +358,8 @@ async def test_pagination_links(testapp, testdatabase):
         '<https://api.xsnippet.org/v1/snippets?limit=3>; rel="first", '
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=8>; rel="next"'
     )
-    assert resp1.headers['Link'] == expected_link1
-    assert [s['id'] for s in await resp1.json()] == [10, 9, 8]
+    assert resp1.headers["Link"] == expected_link1
+    assert [s["id"] for s in await resp1.json()] == [10, 9, 8]
 
     # We should have seen snippets with ids 7, 6 and 5. Prev page is the
     # beginning of the list, thus, no marker
@@ -322,8 +369,8 @@ async def test_pagination_links(testapp, testdatabase):
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=5>; rel="next", '
         '<https://api.xsnippet.org/v1/snippets?limit=3>; rel="prev"'
     )
-    assert resp2.headers['Link'] == expected_link2
-    assert [s['id'] for s in await resp2.json()] == [7, 6, 5]
+    assert resp2.headers["Link"] == expected_link2
+    assert [s["id"] for s in await resp2.json()] == [7, 6, 5]
 
     # We should have seen snippets with ids 4, 3 and 2
     resp3 = await _get_next_page(testapp, limit=3, marker=5)
@@ -332,8 +379,8 @@ async def test_pagination_links(testapp, testdatabase):
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=2>; rel="next", '
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=8>; rel="prev"'
     )
-    assert resp3.headers['Link'] == expected_link3
-    assert [s['id'] for s in await resp3.json()] == [4, 3, 2]
+    assert resp3.headers["Link"] == expected_link3
+    assert [s["id"] for s in await resp3.json()] == [4, 3, 2]
 
     # We should have seen the snippet with id 1. No link to the next page,
     # as we have reached the end of the list
@@ -342,24 +389,24 @@ async def test_pagination_links(testapp, testdatabase):
         '<https://api.xsnippet.org/v1/snippets?limit=3>; rel="first", '
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=5>; rel="prev"'
     )
-    assert resp4.headers['Link'] == expected_link4
-    assert [s['id'] for s in await resp4.json()] == [1]
+    assert resp4.headers["Link"] == expected_link4
+    assert [s["id"] for s in await resp4.json()] == [1]
 
 
-async def test_pagination_links_one_page_larger_than_whole_list(testapp, testdatabase):
+async def test_pagination_links_one_page_larger_than_whole_list(
+    testapp, testdatabase
+):
     # Put 10 snippets into the db
     now = datetime.datetime.utcnow().replace(microsecond=0)
     snippets = [
         {
-            '_id': i + 1,
-            'title': 'snippet #%d' % (i + 1),
-            'changesets': [
-                {'content': '(println "Hello, World!")'},
-            ],
-            'syntax': 'clojure',
-            'tags': ['tag_b'],
-            'created_at': (now + datetime.timedelta(seconds=1)),
-            'updated_at': (now + datetime.timedelta(seconds=1)),
+            "_id": i + 1,
+            "title": "snippet #%d" % (i + 1),
+            "changesets": [{"content": '(println "Hello, World!")'}],
+            "syntax": "clojure",
+            "tags": ["tag_b"],
+            "created_at": (now + datetime.timedelta(seconds=1)),
+            "updated_at": (now + datetime.timedelta(seconds=1)),
         }
         for i in range(10)
     ]
@@ -367,45 +414,62 @@ async def test_pagination_links_one_page_larger_than_whole_list(testapp, testdat
 
     # Default limit is 20 and there no prev/next pages - only the first one
     resp = await _get_next_page(testapp, limit=None)
-    expected_link = '<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'
-    assert resp.headers['Link'] == expected_link
-    assert [s['id'] for s in await resp.json()] == list(reversed(range(1, 11)))
+    expected_link = (
+        '<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'
+    )
+    assert resp.headers["Link"] == expected_link
+    assert [s["id"] for s in await resp.json()] == list(reversed(range(1, 11)))
 
 
-@pytest.mark.parametrize('protocol, host, link', [
-    ('http', 'api.xsnippet.org',
-     '<http://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
-    ('https', 'api.xsnippet.org',
-     '<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"'),
-    ('https', 'api.xsnippet.org:443',
-     '<https://api.xsnippet.org:443/v1/snippets?limit=20>; rel="first"'),
-])
+@pytest.mark.parametrize(
+    "protocol, host, link",
+    [
+        (
+            "http",
+            "api.xsnippet.org",
+            '<http://api.xsnippet.org/v1/snippets?limit=20>; rel="first"',
+        ),
+        (
+            "https",
+            "api.xsnippet.org",
+            '<https://api.xsnippet.org/v1/snippets?limit=20>; rel="first"',
+        ),
+        (
+            "https",
+            "api.xsnippet.org:443",
+            '<https://api.xsnippet.org:443/v1/snippets?limit=20>; rel="first"',
+        ),
+    ],
+)
 async def test_pagination_link_respect_headers(testapp, protocol, host, link):
-    resp = await testapp.get('/v1/snippets', headers={
-        # Pass the additional headers, that are set by nginx in the production
-        # deployment, so that we ensure we generate the correct links for
-        # users.
-        'Host': host,
-        'X-Forwarded-Proto':  protocol,
-    })
+    resp = await testapp.get(
+        "/v1/snippets",
+        headers={
+            # Pass the additional headers, that are set by nginx in the production
+            # deployment, so that we ensure we generate the correct links for
+            # users.
+            "Host": host,
+            "X-Forwarded-Proto": protocol,
+        },
+    )
 
-    assert resp.headers['Link'] == link
+    assert resp.headers["Link"] == link
 
 
-async def test_pagination_links_num_of_items_is_multiple_of_pages(testapp, testdatabase):
+async def test_pagination_links_num_of_items_is_multiple_of_pages(
+    testapp, testdatabase
+):
     # Put 12 snippets into the db
     now = datetime.datetime.utcnow().replace(microsecond=0)
     snippets = [
         {
-            '_id': i + 1,
-            'title': 'snippet #%d' % (i + 1),
-            'changesets': [
-                {'content': '(println "Hello, World!")'},
-            ],
-            'syntax': 'clojure',
-            'tags': ['tag_b'],
-            'created_at': (now + datetime.timedelta(seconds=1)),
-            'updated_at': (now + datetime.timedelta(seconds=1)),
+            "_id": i + 1,
+            "title": "snippet #%d" % (i + 1),
+            "changesets": [{"content": '(println "Hello, World!")'}],
+            "syntax": "clojure",
+            "tags": ["tag_b"],
+            "created_at": (now + datetime.timedelta(seconds=1)),
+            "updated_at": (now + datetime.timedelta(seconds=1)),
         }
         for i in range(12)
     ]
@@ -418,8 +482,8 @@ async def test_pagination_links_num_of_items_is_multiple_of_pages(testapp, testd
         '<https://api.xsnippet.org/v1/snippets?limit=4>; rel="first", '
         '<https://api.xsnippet.org/v1/snippets?limit=4&marker=9>; rel="next"'
     )
-    assert resp1.headers['Link'] == expected_link1
-    assert [s['id'] for s in await resp1.json()] == [12, 11, 10, 9]
+    assert resp1.headers["Link"] == expected_link1
+    assert [s["id"] for s in await resp1.json()] == [12, 11, 10, 9]
 
     # We should have seen snippets with ids 8, 7, 6 and 5. Link to the prev
     # page is a link to the beginning of the list
@@ -429,8 +493,8 @@ async def test_pagination_links_num_of_items_is_multiple_of_pages(testapp, testd
         '<https://api.xsnippet.org/v1/snippets?limit=4&marker=5>; rel="next", '
         '<https://api.xsnippet.org/v1/snippets?limit=4>; rel="prev"'
     )
-    assert resp2.headers['Link'] == expected_link2
-    assert [s['id'] for s in await resp2.json()] == [8, 7, 6, 5]
+    assert resp2.headers["Link"] == expected_link2
+    assert [s["id"] for s in await resp2.json()] == [8, 7, 6, 5]
 
     # We should have seen snippets with ids 4, 3, 2 and 1. Link to the next
     # page is not rendered, as we reached the end of the list
@@ -439,23 +503,21 @@ async def test_pagination_links_num_of_items_is_multiple_of_pages(testapp, testd
         '<https://api.xsnippet.org/v1/snippets?limit=4>; rel="first", '
         '<https://api.xsnippet.org/v1/snippets?limit=4&marker=9>; rel="prev"'
     )
-    assert resp3.headers['Link'] == expected_link3
-    assert [s['id'] for s in await resp3.json()] == [4, 3, 2, 1]
+    assert resp3.headers["Link"] == expected_link3
+    assert [s["id"] for s in await resp3.json()] == [4, 3, 2, 1]
 
 
 async def test_pagination_links_non_consecutive_ids(testapp, testdatabase):
     now = datetime.datetime.utcnow().replace(microsecond=0)
     snippets = [
         {
-            '_id': i,
-            'title': 'snippet #%d' % i,
-            'changesets': [
-                {'content': '(println "Hello, World!")'},
-            ],
-            'syntax': 'clojure',
-            'tags': ['tag_b'],
-            'created_at': (now + datetime.timedelta(seconds=1)),
-            'updated_at': (now + datetime.timedelta(seconds=1)),
+            "_id": i,
+            "title": "snippet #%d" % i,
+            "changesets": [{"content": '(println "Hello, World!")'}],
+            "syntax": "clojure",
+            "tags": ["tag_b"],
+            "created_at": (now + datetime.timedelta(seconds=1)),
+            "updated_at": (now + datetime.timedelta(seconds=1)),
         }
         for i in [1, 7, 17, 23, 24, 29, 31, 87, 93, 104]
     ]
@@ -466,8 +528,8 @@ async def test_pagination_links_non_consecutive_ids(testapp, testdatabase):
         '<https://api.xsnippet.org/v1/snippets?limit=3>; rel="first", '
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=87>; rel="next"'
     )
-    assert resp1.headers['Link'] == expected_link1
-    assert [s['id'] for s in await resp1.json()] == [104, 93, 87]
+    assert resp1.headers["Link"] == expected_link1
+    assert [s["id"] for s in await resp1.json()] == [104, 93, 87]
 
     resp2 = await _get_next_page(testapp, limit=3, marker=87)
     expected_link2 = (
@@ -475,8 +537,8 @@ async def test_pagination_links_non_consecutive_ids(testapp, testdatabase):
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=24>; rel="next", '
         '<https://api.xsnippet.org/v1/snippets?limit=3>; rel="prev"'
     )
-    assert resp2.headers['Link'] == expected_link2
-    assert [s['id'] for s in await resp2.json()] == [31, 29, 24]
+    assert resp2.headers["Link"] == expected_link2
+    assert [s["id"] for s in await resp2.json()] == [31, 29, 24]
 
     resp3 = await _get_next_page(testapp, limit=3, marker=24)
     expected_link3 = (
@@ -484,104 +546,122 @@ async def test_pagination_links_non_consecutive_ids(testapp, testdatabase):
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=7>; rel="next", '
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=87>; rel="prev"'
     )
-    assert resp3.headers['Link'] == expected_link3
-    assert [s['id'] for s in await resp3.json()] == [23, 17, 7]
+    assert resp3.headers["Link"] == expected_link3
+    assert [s["id"] for s in await resp3.json()] == [23, 17, 7]
 
     resp4 = await _get_next_page(testapp, limit=3, marker=7)
     expected_link4 = (
         '<https://api.xsnippet.org/v1/snippets?limit=3>; rel="first", '
         '<https://api.xsnippet.org/v1/snippets?limit=3&marker=24>; rel="prev"'
     )
-    assert resp4.headers['Link'] == expected_link4
-    assert [s['id'] for s in await resp4.json()] == [1]
+    assert resp4.headers["Link"] == expected_link4
+    assert [s["id"] for s in await resp4.json()] == [1]
 
 
 async def test_get_snippets_pagination_not_found(testapp):
     resp = await testapp.get(
-        '/v1/snippets?limit=10&marker=1234567890',
-        headers={
-            'Accept': 'application/json',
-        })
+        "/v1/snippets?limit=10&marker=1234567890",
+        headers={"Accept": "application/json"},
+    )
     assert resp.status == 404
     assert await resp.json() == {
-        'message': 'Sorry, cannot complete the request since `marker` '
-                   'points to a nonexistent snippet.',
+        "message": "Sorry, cannot complete the request since `marker` "
+        "points to a nonexistent snippet."
     }
 
 
-@pytest.mark.parametrize('snippet, rv', [
-    ({'content': 'def foo(): pass'},
-     {'id': 1,
-      'title': None,
-      'content': 'def foo(): pass',
-      'syntax': None,
-      'tags': [],
-      'created_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'),
-      'updated_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}')}),
-
-    ({'title': 'snippet #1',
-      'content': 'def foo(): pass',
-      'syntax': 'python',
-      'tags': ['tag_a', 'tag_b']},
-     {'id': 1,
-      'title': 'snippet #1',
-      'content': 'def foo(): pass',
-      'syntax': 'python',
-      'tags': ['tag_a', 'tag_b'],
-      'created_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'),
-      'updated_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}')}),
-])
+@pytest.mark.parametrize(
+    "snippet, rv",
+    [
+        (
+            {"content": "def foo(): pass"},
+            {
+                "id": 1,
+                "title": None,
+                "content": "def foo(): pass",
+                "syntax": None,
+                "tags": [],
+                "created_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+                "updated_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+            },
+        ),
+        (
+            {
+                "title": "snippet #1",
+                "content": "def foo(): pass",
+                "syntax": "python",
+                "tags": ["tag_a", "tag_b"],
+            },
+            {
+                "id": 1,
+                "title": "snippet #1",
+                "content": "def foo(): pass",
+                "syntax": "python",
+                "tags": ["tag_a", "tag_b"],
+                "created_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+                "updated_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+            },
+        ),
+    ],
+)
 async def test_post_snippet(testapp, testconf, snippet, rv):
-    testconf['SNIPPET_SYNTAXES'] = ['python', 'clojure']
+    testconf["SNIPPET_SYNTAXES"] = ["python", "clojure"]
 
-    resp = await testapp.post('/v1/snippets', data=json.dumps(snippet))
+    resp = await testapp.post("/v1/snippets", data=json.dumps(snippet))
 
     assert resp.status == 201
     assert await resp.json() == rv
 
 
-@pytest.mark.parametrize('snippet, rv', [
-    (
-        {},
-        {'message': '`content` - required field.'},
-    ),
-    (
-        {'content': 'test', 'title': 42},
-        {'message': '`title` - must be of string type.'},
-    ),
-    (
-        {'content': 42},
-        {'message': '`content` - must be of string type.'},
-    ),
-    (
-        {'content': ''},
-        {'message': '`content` - empty values not allowed.'},
-    ),
-    (
-        {'content': 'test', 'tags': ['white space']},
-        {'message': '`tags` - {0: ["value does not match regex \'[\\\\w_-]+\'"]}.'},
-    ),
-    (
-        {'content': 'test', 'created_at': '2016-09-11T19:07:43'},
-        {'message': '`created_at` - field is read-only.'},
-    ),
-    (
-        {'content': 'test', 'updated_at': '2016-09-11T19:07:43'},
-        {'message': '`updated_at` - field is read-only.'},
-    ),
-    (
-        {'content': 'test', 'non-existent-key': 'you-shall-not-pass'},
-        {'message': '`non-existent-key` - unknown field.'},
-    ),
-    (
-        {'content': 'test', 'syntax': 'go'},
-        {'message': '`syntax` - unallowed value go.'},
-    ),
-])
+@pytest.mark.parametrize(
+    "snippet, rv",
+    [
+        ({}, {"message": "`content` - required field."}),
+        (
+            {"content": "test", "title": 42},
+            {"message": "`title` - must be of string type."},
+        ),
+        ({"content": 42}, {"message": "`content` - must be of string type."}),
+        (
+            {"content": ""},
+            {"message": "`content` - empty values not allowed."},
+        ),
+        (
+            {"content": "test", "tags": ["white space"]},
+            {
+                "message": "`tags` - {0: [\"value does not match regex '[\\\\w_-]+'\"]}."
+            },
+        ),
+        (
+            {"content": "test", "created_at": "2016-09-11T19:07:43"},
+            {"message": "`created_at` - field is read-only."},
+        ),
+        (
+            {"content": "test", "updated_at": "2016-09-11T19:07:43"},
+            {"message": "`updated_at` - field is read-only."},
+        ),
+        (
+            {"content": "test", "non-existent-key": "you-shall-not-pass"},
+            {"message": "`non-existent-key` - unknown field."},
+        ),
+        (
+            {"content": "test", "syntax": "go"},
+            {"message": "`syntax` - unallowed value go."},
+        ),
+    ],
+)
 async def test_post_snippet_bad_request(snippet, rv, testapp, testconf):
-    testconf['SNIPPET_SYNTAXES'] = ['python', 'clojure']
+    testconf["SNIPPET_SYNTAXES"] = ["python", "clojure"]
 
-    resp = await testapp.post('/v1/snippets', data=json.dumps(snippet))
+    resp = await testapp.post("/v1/snippets", data=json.dumps(snippet))
 
     assert resp.status == 400
     assert await resp.json() == rv
@@ -590,240 +670,280 @@ async def test_post_snippet_bad_request(snippet, rv, testapp, testconf):
 async def test_data_model_indexes_exist(testapp, testdatabase):
     res = await testdatabase.snippets.index_information()
 
-    assert res['title_idx']['key'] == [('title', 1)]
-    assert res['title_idx']['partialFilterExpression'] == {
-        'title': {'$type': 'string'}
+    assert res["title_idx"]["key"] == [("title", 1)]
+    assert res["title_idx"]["partialFilterExpression"] == {
+        "title": {"$type": "string"}
     }
-    assert res['tags_idx']['key'] == [('tags', 1)]
-    assert res['updated_id_idx']['key'] == [('updated_at', -1), ('_id', -1)]
-    assert res['created_id_idx']['key'] == [('created_at', -1), ('_id', -1)]
+    assert res["tags_idx"]["key"] == [("tags", 1)]
+    assert res["updated_id_idx"]["key"] == [("updated_at", -1), ("_id", -1)]
+    assert res["created_id_idx"]["key"] == [("created_at", -1), ("_id", -1)]
 
 
 async def test_get_snippet(testapp, snippets):
-    resp = await testapp.get('/v1/snippets/%d' % snippets[0]['id'])
+    resp = await testapp.get("/v1/snippets/%d" % snippets[0]["id"])
 
     assert resp.status == 200
     assert await resp.json() == {
-        'id': 1,
-        'title': 'snippet #1',
-        'content': 'def foo(): pass',
-        'syntax': 'python',
-        'tags': ['tag_a', 'tag_b'],
-        'created_at': '2018-01-24T22:26:35',
-        'updated_at': '2018-01-24T22:26:35',
+        "id": 1,
+        "title": "snippet #1",
+        "content": "def foo(): pass",
+        "syntax": "python",
+        "tags": ["tag_a", "tag_b"],
+        "created_at": "2018-01-24T22:26:35",
+        "updated_at": "2018-01-24T22:26:35",
     }
 
 
 async def test_get_snippet_not_found(testapp):
-    resp = await testapp.get('/v1/snippets/123456789')
+    resp = await testapp.get("/v1/snippets/123456789")
 
     assert resp.status == 404
-    assert await resp.json() == {'message': 'Sorry, cannot find the requested snippet.'}
+    assert await resp.json() == {
+        "message": "Sorry, cannot find the requested snippet."
+    }
 
 
 async def test_get_snippet_bad_request(testapp):
-    resp = await testapp.get('/v1/snippets/deadbeef')
+    resp = await testapp.get("/v1/snippets/deadbeef")
 
     assert resp.status == 400
-    assert await resp.json() == {'message': '`id` - must be of integer type.'}
+    assert await resp.json() == {"message": "`id` - must be of integer type."}
 
 
 async def test_delete_snippet(testapp, snippets):
-    resp = await testapp.delete('/v1/snippets/%d' % snippets[0]['id'])
+    resp = await testapp.delete("/v1/snippets/%d" % snippets[0]["id"])
 
     assert resp.status == 204
-    assert await resp.text() == ''
+    assert await resp.text() == ""
 
 
 async def test_delete_snippet_not_found(testapp):
-    resp = await testapp.delete('/v1/snippets/123456789')
+    resp = await testapp.delete("/v1/snippets/123456789")
 
     assert resp.status == 404
-    assert await resp.json() == {'message': 'Sorry, cannot find the requested snippet.'}
+    assert await resp.json() == {
+        "message": "Sorry, cannot find the requested snippet."
+    }
 
 
 async def test_delete_snippet_bad_request(testapp):
-    resp = await testapp.delete('/v1/snippets/deadbeef')
+    resp = await testapp.delete("/v1/snippets/deadbeef")
 
     assert resp.status == 400
-    assert await resp.json() == {'message': '`id` - must be of integer type.'}
+    assert await resp.json() == {"message": "`id` - must be of integer type."}
 
 
-@pytest.mark.parametrize('snippet, rv', [
-    ({'content': 'def foo(): pass'},
-     {'id': 1,
-      'title': None,
-      'content': 'def foo(): pass',
-      'syntax': None,
-      'tags': [],
-      'created_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'),
-      'updated_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}')}),
-
-    ({'title': 'snippet #1',
-      'content': 'def foo(): pass',
-      'syntax': 'python',
-      'tags': ['tag_a', 'tag_b']},
-     {'id': 1,
-      'title': 'snippet #1',
-      'content': 'def foo(): pass',
-      'syntax': 'python',
-      'tags': ['tag_a', 'tag_b'],
-      'created_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'),
-      'updated_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}')}),
-])
+@pytest.mark.parametrize(
+    "snippet, rv",
+    [
+        (
+            {"content": "def foo(): pass"},
+            {
+                "id": 1,
+                "title": None,
+                "content": "def foo(): pass",
+                "syntax": None,
+                "tags": [],
+                "created_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+                "updated_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+            },
+        ),
+        (
+            {
+                "title": "snippet #1",
+                "content": "def foo(): pass",
+                "syntax": "python",
+                "tags": ["tag_a", "tag_b"],
+            },
+            {
+                "id": 1,
+                "title": "snippet #1",
+                "content": "def foo(): pass",
+                "syntax": "python",
+                "tags": ["tag_a", "tag_b"],
+                "created_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+                "updated_at": pytest.regex(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+                ),
+            },
+        ),
+    ],
+)
 async def test_put_snippet(testapp, snippets, snippet, rv):
-    resp = await testapp.put('/v1/snippets/1', data=json.dumps(snippet))
+    resp = await testapp.put("/v1/snippets/1", data=json.dumps(snippet))
 
     assert resp.status == 200
     assert await resp.json() == rv
 
 
 async def test_put_snippet_bad_id(testapp):
-    resp = await testapp.put('/v1/snippets/deadbeef', data=json.dumps({'content': 'test'}))
+    resp = await testapp.put(
+        "/v1/snippets/deadbeef", data=json.dumps({"content": "test"})
+    )
 
     assert resp.status == 400
-    assert await resp.json() == {'message': '`id` - must be of integer type.'}
+    assert await resp.json() == {"message": "`id` - must be of integer type."}
 
 
 async def test_put_snippet_not_found(testapp):
-    resp = await testapp.put('/v1/snippets/123456789', data=json.dumps({'content': 'test'}))
+    resp = await testapp.put(
+        "/v1/snippets/123456789", data=json.dumps({"content": "test"})
+    )
 
     assert resp.status == 404
-    assert await resp.json() == {'message': 'Sorry, cannot find the requested snippet.'}
+    assert await resp.json() == {
+        "message": "Sorry, cannot find the requested snippet."
+    }
 
 
-@pytest.mark.parametrize('snippet, rv', [
-    (
-        {},
-        {'message': '`content` - required field.'},
-    ),
-    (
-        {'content': 'test', 'title': 42},
-        {'message': '`title` - must be of string type.'},
-    ),
-    (
-        {'content': 42},
-        {'message': '`content` - must be of string type.'},
-    ),
-    (
-        {'content': ''},
-        {'message': '`content` - empty values not allowed.'},
-    ),
-    (
-        {'content': 'test', 'tags': ['white space']},
-        {'message': '`tags` - {0: ["value does not match regex \'[\\\\w_-]+\'"]}.'},
-    ),
-    (
-        {'content': 'test', 'created_at': '2016-09-11T19:07:43'},
-        {'message': '`created_at` - field is read-only.'},
-    ),
-    (
-        {'content': 'test', 'updated_at': '2016-09-11T19:07:43'},
-        {'message': '`updated_at` - field is read-only.'},
-    ),
-    (
-        {'content': 'test', 'non-existent-key': 'you-shall-not-pass'},
-        {'message': '`non-existent-key` - unknown field.'},
-    ),
-    (
-        {'content': 'test', 'syntax': 'go'},
-        {'message': '`syntax` - unallowed value go.'},
-    ),
-])
-async def test_put_snippet_bad_request(snippet, rv, testapp, testconf, snippets):
-    testconf['SNIPPET_SYNTAXES'] = ['python', 'clojure']
+@pytest.mark.parametrize(
+    "snippet, rv",
+    [
+        ({}, {"message": "`content` - required field."}),
+        (
+            {"content": "test", "title": 42},
+            {"message": "`title` - must be of string type."},
+        ),
+        ({"content": 42}, {"message": "`content` - must be of string type."}),
+        (
+            {"content": ""},
+            {"message": "`content` - empty values not allowed."},
+        ),
+        (
+            {"content": "test", "tags": ["white space"]},
+            {
+                "message": "`tags` - {0: [\"value does not match regex '[\\\\w_-]+'\"]}."
+            },
+        ),
+        (
+            {"content": "test", "created_at": "2016-09-11T19:07:43"},
+            {"message": "`created_at` - field is read-only."},
+        ),
+        (
+            {"content": "test", "updated_at": "2016-09-11T19:07:43"},
+            {"message": "`updated_at` - field is read-only."},
+        ),
+        (
+            {"content": "test", "non-existent-key": "you-shall-not-pass"},
+            {"message": "`non-existent-key` - unknown field."},
+        ),
+        (
+            {"content": "test", "syntax": "go"},
+            {"message": "`syntax` - unallowed value go."},
+        ),
+    ],
+)
+async def test_put_snippet_bad_request(
+    snippet, rv, testapp, testconf, snippets
+):
+    testconf["SNIPPET_SYNTAXES"] = ["python", "clojure"]
 
-    resp = await testapp.put('/v1/snippets/%d' % snippets[0]['id'], data=json.dumps(snippet))
+    resp = await testapp.put(
+        "/v1/snippets/%d" % snippets[0]["id"], data=json.dumps(snippet)
+    )
 
     assert resp.status == 400
     assert await resp.json() == rv
 
 
 async def test_patch_snippet(testapp, snippets):
-    resp = await testapp.patch('/v1/snippets/%d' % snippets[0]['id'], data=json.dumps({
-        'content': 'test',
-    }))
+    resp = await testapp.patch(
+        "/v1/snippets/%d" % snippets[0]["id"],
+        data=json.dumps({"content": "test"}),
+    )
 
     assert resp.status == 200
     assert await resp.json() == {
-        'id': 1,
-        'title': 'snippet #1',
-        'content': 'test',
-        'syntax': 'python',
-        'tags': ['tag_a', 'tag_b'],
-        'created_at': '2018-01-24T22:26:35',
-        'updated_at': pytest.regex(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'),
+        "id": 1,
+        "title": "snippet #1",
+        "content": "test",
+        "syntax": "python",
+        "tags": ["tag_a", "tag_b"],
+        "created_at": "2018-01-24T22:26:35",
+        "updated_at": pytest.regex(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"),
     }
 
 
 async def test_patch_snippet_bad_id(testapp):
-    resp = await testapp.patch('/v1/snippets/deadbeef', data=json.dumps({'content': 'test'}))
+    resp = await testapp.patch(
+        "/v1/snippets/deadbeef", data=json.dumps({"content": "test"})
+    )
 
     assert resp.status == 400
-    assert await resp.json() == {'message': '`id` - must be of integer type.'}
+    assert await resp.json() == {"message": "`id` - must be of integer type."}
 
 
 async def test_patch_snippet_not_found(testapp):
-    resp = await testapp.patch('/v1/snippets/123456789', data=json.dumps({'content': 'test'}))
+    resp = await testapp.patch(
+        "/v1/snippets/123456789", data=json.dumps({"content": "test"})
+    )
 
     assert resp.status == 404
-    assert await resp.json() == {'message': 'Sorry, cannot find the requested snippet.'}
+    assert await resp.json() == {
+        "message": "Sorry, cannot find the requested snippet."
+    }
 
 
-@pytest.mark.parametrize('snippet, rv', [
-    (
-        {'title': 42},
-        {'message': '`title` - must be of string type.'},
-    ),
-    (
-        {'content': 42},
-        {'message': '`content` - must be of string type.'},
-    ),
-    (
-        {'content': ''},
-        {'message': '`content` - empty values not allowed.'},
-    ),
-    (
-        {'tags': ['white space']},
-        {'message': '`tags` - {0: ["value does not match regex \'[\\\\w_-]+\'"]}.'},
-    ),
-    (
-        {'created_at': '2016-09-11T19:07:43'},
-        {'message': '`created_at` - field is read-only.'},
-    ),
-    (
-        {'updated_at': '2016-09-11T19:07:43'},
-        {'message': '`updated_at` - field is read-only.'},
-    ),
-    (
-        {'non-existent-key': 'you-shall-not-pass'},
-        {'message': '`non-existent-key` - unknown field.'},
-    ),
-    (
-        {'syntax': 'go'},
-        {'message': '`syntax` - unallowed value go.'},
-    ),
-])
-async def test_patch_snippet_bad_request(snippet, rv, testapp, testconf, snippets):
-    testconf['SNIPPET_SYNTAXES'] = ['python', 'clojure']
+@pytest.mark.parametrize(
+    "snippet, rv",
+    [
+        ({"title": 42}, {"message": "`title` - must be of string type."}),
+        ({"content": 42}, {"message": "`content` - must be of string type."}),
+        (
+            {"content": ""},
+            {"message": "`content` - empty values not allowed."},
+        ),
+        (
+            {"tags": ["white space"]},
+            {
+                "message": "`tags` - {0: [\"value does not match regex '[\\\\w_-]+'\"]}."
+            },
+        ),
+        (
+            {"created_at": "2016-09-11T19:07:43"},
+            {"message": "`created_at` - field is read-only."},
+        ),
+        (
+            {"updated_at": "2016-09-11T19:07:43"},
+            {"message": "`updated_at` - field is read-only."},
+        ),
+        (
+            {"non-existent-key": "you-shall-not-pass"},
+            {"message": "`non-existent-key` - unknown field."},
+        ),
+        ({"syntax": "go"}, {"message": "`syntax` - unallowed value go."}),
+    ],
+)
+async def test_patch_snippet_bad_request(
+    snippet, rv, testapp, testconf, snippets
+):
+    testconf["SNIPPET_SYNTAXES"] = ["python", "clojure"]
 
-    resp = await testapp.patch('/v1/snippets/%d' % snippets[0]['id'], data=json.dumps(snippet))
+    resp = await testapp.patch(
+        "/v1/snippets/%d" % snippets[0]["id"], data=json.dumps(snippet)
+    )
 
     assert resp.status == 400
     assert await resp.json() == rv
 
 
-@pytest.mark.parametrize('method', [
-    'put',
-    'patch',
-    'delete',
-])
-async def test_snippet_update_is_not_exposed(method, testapp, testconf, snippets):
-    testconf.pop('_SUDO', None)
+@pytest.mark.parametrize("method", ["put", "patch", "delete"])
+async def test_snippet_update_is_not_exposed(
+    method, testapp, testconf, snippets
+):
+    testconf.pop("_SUDO", None)
     request = getattr(testapp, method)
 
-    snippet = {'content': 'test'}
-    resp = await request('/v1/snippets/%d' % snippets[0]['id'], data=json.dumps(snippet))
+    snippet = {"content": "test"}
+    resp = await request(
+        "/v1/snippets/%d" % snippets[0]["id"], data=json.dumps(snippet)
+    )
 
     assert resp.status == 403
-    assert await resp.json() == {'message': 'Not yet. :)'}
+    assert await resp.json() == {"message": "Not yet. :)"}

--- a/tests/resources/test_syntaxes.py
+++ b/tests/resources/test_syntaxes.py
@@ -13,65 +13,45 @@ import pytest
 
 async def test_get_syntaxes_default_conf(testapp):
     resp = await testapp.get(
-        '/v1/syntaxes',
-        headers={
-            'Accept': 'application/json',
-        }
+        "/v1/syntaxes", headers={"Accept": "application/json"}
     )
     assert resp.status == 200
     assert await resp.json() == []
 
 
-@pytest.mark.parametrize('syntaxes', [
-    [],
-    ['clojure', 'python'],
-])
+@pytest.mark.parametrize("syntaxes", [[], ["clojure", "python"]])
 async def test_get_syntaxes_overriden_conf(testapp, testconf, syntaxes):
-    testconf['SNIPPET_SYNTAXES'] = syntaxes
+    testconf["SNIPPET_SYNTAXES"] = syntaxes
 
     resp = await testapp.get(
-        '/v1/syntaxes',
-        headers={
-            'Accept': 'application/json',
-        }
+        "/v1/syntaxes", headers={"Accept": "application/json"}
     )
     assert resp.status == 200
     assert await resp.json() == syntaxes
 
 
 async def test_get_syntaxes_overriden_conf_no_syntaxes(testapp, testconf):
-    testconf['SNIPPET_SYNTAXES'] = []
+    testconf["SNIPPET_SYNTAXES"] = []
 
     resp = await testapp.get(
-        '/v1/syntaxes',
-        headers={
-            'Accept': 'application/json',
-        }
+        "/v1/syntaxes", headers={"Accept": "application/json"}
     )
     assert resp.status == 200
     assert await resp.json() == []
 
 
-@pytest.mark.parametrize('method', ['delete', 'post', 'put'])
+@pytest.mark.parametrize("method", ["delete", "post", "put"])
 async def test_get_syntaxes_unsupported_method(testapp, method):
     func = getattr(testapp, method)
 
-    resp = await func(
-        '/v1/syntaxes',
-        headers={
-            'Accept': 'application/json',
-        }
-    )
+    resp = await func("/v1/syntaxes", headers={"Accept": "application/json"})
     assert resp.status == 405
-    assert 'Method Not Allowed' in await resp.text()
+    assert "Method Not Allowed" in await resp.text()
 
 
 async def test_get_syntaxes_unsupported_accept_type(testapp):
     resp = await testapp.get(
-        '/v1/syntaxes',
-        headers={
-            'Accept': 'application/xml',
-        }
+        "/v1/syntaxes", headers={"Accept": "application/xml"}
     )
     assert resp.status == 406
-    assert 'Not Acceptable' in await resp.text()
+    assert "Not Acceptable" in await resp.text()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -16,9 +16,12 @@ async def test_deprecated_routes(testapp):
 
     def _extract_path(route):
         info = route.resource.get_info()
-        return info.get('path') or info.get('formatter')
-    routes = {_extract_path(route): route.handler for route in app.router.routes()}
+        return info.get("path") or info.get("formatter")
 
-    assert routes['/snippets'] is routes['/v1/snippets']
-    assert routes['/snippets/{id}'] is routes['/v1/snippets/{id}']
-    assert routes['/syntaxes'] is routes['/v1/syntaxes']
+    routes = {
+        _extract_path(route): route.handler for route in app.router.routes()
+    }
+
+    assert routes["/snippets"] is routes["/v1/snippets"]
+    assert routes["/snippets/{id}"] is routes["/v1/snippets/{id}"]
+    assert routes["/syntaxes"] is routes["/v1/syntaxes"]

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -4,29 +4,31 @@ from xsnippet.api.conf import get_conf
 
 
 def test_get_conf(monkeypatch):
-    monkeypatch.setenv('XSNIPPET_SERVER_HOST', '1.2.3.4')
-    monkeypatch.setenv('XSNIPPET_SERVER_PORT', 1234)
-    monkeypatch.setenv('XSNIPPET_SERVER_ACCESS_LOG_FORMAT', '%x %y')
-    monkeypatch.setenv('XSNIPPET_DATABASE_CONNECTION_URI', 'mongodb://42.42.42.42/test')
-    monkeypatch.setenv('XSNIPPET_SNIPPET_SYNTAXES', 'foo,bar')
-    monkeypatch.setenv('XSNIPPET_AUTH_SECRET', 'x$3cret')
+    monkeypatch.setenv("XSNIPPET_SERVER_HOST", "1.2.3.4")
+    monkeypatch.setenv("XSNIPPET_SERVER_PORT", 1234)
+    monkeypatch.setenv("XSNIPPET_SERVER_ACCESS_LOG_FORMAT", "%x %y")
+    monkeypatch.setenv(
+        "XSNIPPET_DATABASE_CONNECTION_URI", "mongodb://42.42.42.42/test"
+    )
+    monkeypatch.setenv("XSNIPPET_SNIPPET_SYNTAXES", "foo,bar")
+    monkeypatch.setenv("XSNIPPET_AUTH_SECRET", "x$3cret")
 
     assert get_conf() == {
-        'SERVER_HOST': '1.2.3.4',
-        'SERVER_PORT': 1234,
-        'SERVER_ACCESS_LOG_FORMAT': '%x %y',
-        'DATABASE_CONNECTION_URI': 'mongodb://42.42.42.42/test',
-        'SNIPPET_SYNTAXES': ['foo', 'bar'],
-        'AUTH_SECRET': 'x$3cret',
+        "SERVER_HOST": "1.2.3.4",
+        "SERVER_PORT": 1234,
+        "SERVER_ACCESS_LOG_FORMAT": "%x %y",
+        "DATABASE_CONNECTION_URI": "mongodb://42.42.42.42/test",
+        "SNIPPET_SYNTAXES": ["foo", "bar"],
+        "AUTH_SECRET": "x$3cret",
     }
 
 
 def test_get_conf_defaults():
     assert get_conf() == {
-        'SERVER_HOST': '127.0.0.1',
-        'SERVER_PORT': 8000,
-        'SERVER_ACCESS_LOG_FORMAT': '%t %a "%r" %s %b %{User-Agent}i" %Tf',
-        'DATABASE_CONNECTION_URI': 'mongodb://localhost:27017/xsnippet',
-        'SNIPPET_SYNTAXES': [],
-        'AUTH_SECRET': '',
+        "SERVER_HOST": "127.0.0.1",
+        "SERVER_PORT": 8000,
+        "SERVER_ACCESS_LOG_FORMAT": '%t %a "%r" %s %b %{User-Agent}i" %Tf',
+        "DATABASE_CONNECTION_URI": "mongodb://localhost:27017/xsnippet",
+        "SNIPPET_SYNTAXES": [],
+        "AUTH_SECRET": "",
     }

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,3 @@ commands =
     bash -c "docker build \
                 -t xsnippet/xsnippet-api:{posargs:$(git status | grep 'working tree clean' >/dev/null && git rev-parse --short HEAD || echo -n wip)} \
                 ."
-
-[flake8]
-max-line-length = 100

--- a/xsnippet/api/__init__.py
+++ b/xsnippet/api/__init__.py
@@ -10,5 +10,5 @@
     :license: MIT, see LICENSE for details
 """
 
-__version__ = '4.0.0'
-__license__ = 'MIT'
+__version__ = "4.0.0"
+__license__ = "MIT"

--- a/xsnippet/api/__main__.py
+++ b/xsnippet/api/__main__.py
@@ -26,7 +26,7 @@ from xsnippet.api.database import create_connection
 def main(args=sys.argv[1:]):
     # write access/error logs to stderr
     logging.basicConfig()
-    logging.getLogger('aiohttp').setLevel(logging.INFO)
+    logging.getLogger("aiohttp").setLevel(logging.INFO)
 
     conf = get_conf()
     database = create_connection(conf)
@@ -35,25 +35,26 @@ def main(args=sys.argv[1:]):
     # to warn about importance of settings secret before going production. The
     # only reason why we don't enforce it's setting is because we want the app
     # to fly (at least for development purpose) using defaults.
-    if not conf.get('AUTH_SECRET', ''):
+    if not conf.get("AUTH_SECRET", ""):
         warnings.warn(
-            'Auth secret has not been provided. Please generate a long random '
-            'secret before going to production.')
-        conf['AUTH_SECRET'] = binascii.hexlify(os.urandom(32)).decode('ascii')
+            "Auth secret has not been provided. Please generate a long random "
+            "secret before going to production."
+        )
+        conf["AUTH_SECRET"] = binascii.hexlify(os.urandom(32)).decode("ascii")
 
     with picobox.push(picobox.Box()) as box:
-        box.put('conf', conf)
-        box.put('database', database)
+        box.put("conf", conf)
+        box.put("database", database)
 
         web.run_app(
             create_app(conf, database),
-            host=conf['SERVER_HOST'],
-            port=conf['SERVER_PORT'],
-            access_log_format=conf['SERVER_ACCESS_LOG_FORMAT'],
+            host=conf["SERVER_HOST"],
+            port=conf["SERVER_PORT"],
+            access_log_format=conf["SERVER_ACCESS_LOG_FORMAT"],
         )
 
 
 # let's make this module and xsnippet.api package to be executable, so
 # anyone can run it  without entry_points' console script
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/xsnippet/api/application.py
+++ b/xsnippet/api/application.py
@@ -17,8 +17,8 @@ import picobox
 from . import database, routes, middlewares
 
 
-@picobox.pass_('conf')
-@picobox.pass_('database', as_='db')
+@picobox.pass_("conf")
+@picobox.pass_("database", as_="db")
 def create_app(conf, db):
     """Create and return a web application instance.
 
@@ -33,10 +33,7 @@ def create_app(conf, db):
     :rtype: :class:`aiohttp.web.Application`
     """
 
-    app = aiohttp.web.Application(
-        middlewares=[
-            middlewares.auth.auth(conf),
-        ])
+    app = aiohttp.web.Application(middlewares=[middlewares.auth.auth(conf)])
     app.router.add_routes(routes.v1)
     app.on_startup.append(functools.partial(database.setup, db=db))
 

--- a/xsnippet/api/conf.py
+++ b/xsnippet/api/conf.py
@@ -26,18 +26,15 @@ def get_conf():
         # That's why no requests from outer world will be handled. If you
         # want to accept any incoming request on any interface, please
         # change that value to '0.0.0.0'.
-        'SERVER_HOST': decouple.config(
-            'XSNIPPET_SERVER_HOST',
-            default='127.0.0.1'
+        "SERVER_HOST": decouple.config(
+            "XSNIPPET_SERVER_HOST", default="127.0.0.1"
         ),
         # PORT TO LISTEN ON
         #
         # In production you probably will choose a default HTTP port -
         # '80'.  If you want to pick any random free port, just pass '0'.
-        'SERVER_PORT': decouple.config(
-            'XSNIPPET_SERVER_PORT',
-            default=8000,
-            cast=int
+        "SERVER_PORT": decouple.config(
+            "XSNIPPET_SERVER_PORT", default=8000, cast=int
         ),
         # ACCESS LOG FORMAT
         #
@@ -52,25 +49,22 @@ def get_conf():
         #
         # When deployed behind a reverse proxy, consider using the value of
         # headers like X-Real-IP or X-Forwarded-For instead of %a
-        'SERVER_ACCESS_LOG_FORMAT': decouple.config(
-            'XSNIPPET_SERVER_ACCESS_LOG_FORMAT',
+        "SERVER_ACCESS_LOG_FORMAT": decouple.config(
+            "XSNIPPET_SERVER_ACCESS_LOG_FORMAT",
             default='%t %a "%r" %s %b %{User-Agent}i" %Tf',
         ),
         # DATABASE CONNECTION URI
         #
         # Supported backends: MongoDB only
-        'DATABASE_CONNECTION_URI': decouple.config(
-            'XSNIPPET_DATABASE_CONNECTION_URI',
-            default='mongodb://localhost:27017/xsnippet'
+        "DATABASE_CONNECTION_URI": decouple.config(
+            "XSNIPPET_DATABASE_CONNECTION_URI",
+            default="mongodb://localhost:27017/xsnippet",
         ),
-        'SNIPPET_SYNTAXES': decouple.config(
-            'XSNIPPET_SNIPPET_SYNTAXES',
-            default='',
+        "SNIPPET_SYNTAXES": decouple.config(
+            "XSNIPPET_SNIPPET_SYNTAXES",
+            default="",
             # parse a comma separated list retrieved from env variable
-            cast=lambda value: [v for v in value.split(',') if v]
+            cast=lambda value: [v for v in value.split(",") if v],
         ),
-        'AUTH_SECRET': decouple.config(
-            'XSNIPPET_AUTH_SECRET',
-            default=''
-        ),
+        "AUTH_SECRET": decouple.config("XSNIPPET_AUTH_SECRET", default=""),
     }

--- a/xsnippet/api/database.py
+++ b/xsnippet/api/database.py
@@ -25,7 +25,7 @@ def create_connection(conf):
     :return: a database connection
     :rtype: :class:`motor.motor_asyncio.AsyncIOMotorDatabase`
     """
-    mongo = AsyncIOMotorClient(conf['DATABASE_CONNECTION_URI'])
+    mongo = AsyncIOMotorClient(conf["DATABASE_CONNECTION_URI"])
     return mongo.get_database()
 
 
@@ -34,32 +34,32 @@ async def setup(app, db):
     # ensure necessary indexes exist. background=True allows operations
     # read/write operations on collections while indexes are being built
     futures = [
-        db.snippets.create_index('title',
-                                 name='title_idx',
-                                 # create a partial index to skip null values -
-                                 # this is supposed to make the index smaller,
-                                 # so that there is a higher chance it's kept
-                                 # in the main memory
-                                 partialFilterExpression={
-                                    'title': {'$type': 'string'}
-                                 },
-                                 background=True),
-        db.snippets.create_index('tags',
-                                 name='tags_idx',
-                                 background=True),
+        db.snippets.create_index(
+            "title",
+            name="title_idx",
+            # create a partial index to skip null values -
+            # this is supposed to make the index smaller,
+            # so that there is a higher chance it's kept
+            # in the main memory
+            partialFilterExpression={"title": {"$type": "string"}},
+            background=True,
+        ),
+        db.snippets.create_index("tags", name="tags_idx", background=True),
         # use compound indexes for created_at / updated_at attributes for the
         # sake of efficiency of pagination (we need an extra attribute to
         # guarantee uniqueness of the sorting key value). Note, that these
         # indexes still speed up prefix searches by created_at / updated_at
         # when _id is not passed
-        db.snippets.create_index([('created_at', pymongo.DESCENDING),
-                                  ('_id', pymongo.DESCENDING)],
-                                 name='created_id_idx',
-                                 background=True),
-        db.snippets.create_index([('updated_at', pymongo.DESCENDING),
-                                  ('_id', pymongo.DESCENDING)],
-                                 name='updated_id_idx',
-                                 background=True)
+        db.snippets.create_index(
+            [("created_at", pymongo.DESCENDING), ("_id", pymongo.DESCENDING)],
+            name="created_id_idx",
+            background=True,
+        ),
+        db.snippets.create_index(
+            [("updated_at", pymongo.DESCENDING), ("_id", pymongo.DESCENDING)],
+            name="updated_id_idx",
+            background=True,
+        ),
     ]
     return await asyncio.gather(*futures)
 
@@ -76,13 +76,13 @@ class _IdProcessor(pymongo.son_manipulator.SONManipulator):
         # of passed documents (no implicit injection of '_id')
         son = copy.copy(son)
 
-        if son and 'id' in son:
-            son['_id'] = son.pop('id')
+        if son and "id" in son:
+            son["_id"] = son.pop("id")
         return son
 
     def transform_outgoing(self, son, collection):
-        if son and '_id' in son:
-            son['id'] = son.pop('_id')
+        if son and "_id" in son:
+            son["id"] = son.pop("_id")
         return son
 
 
@@ -99,14 +99,15 @@ class _IdIncrementer(pymongo.son_manipulator.SONManipulator):
         # of passed documents (no implicit injection of '_id')
         son = copy.copy(son)
 
-        if son and '_id' not in son:
-            son['_id'] = self._get_next_id(collection)
+        if son and "_id" not in son:
+            son["_id"] = self._get_next_id(collection)
         return son
 
     def _get_next_id(self, collection):
-        result = collection.database['_autoincrement_ids'].find_and_modify(
-            query={'_id': collection.name},
-            update={'$inc': {'next': 1}},
+        result = collection.database["_autoincrement_ids"].find_and_modify(
+            query={"_id": collection.name},
+            update={"$inc": {"next": 1}},
             upsert=True,
-            new=True)
-        return result['next']
+            new=True,
+        )
+        return result["next"]

--- a/xsnippet/api/middlewares/__init__.py
+++ b/xsnippet/api/middlewares/__init__.py
@@ -11,6 +11,4 @@
 from . import auth
 
 
-__all__ = [
-    'auth',
-]
+__all__ = ["auth"]

--- a/xsnippet/api/middlewares/auth.py
+++ b/xsnippet/api/middlewares/auth.py
@@ -27,25 +27,26 @@ def auth(conf):
 
     @web.middleware
     async def _auth(request, handler):
-        secret = conf['AUTH_SECRET']
-        authorization = request.headers.get('Authorization')
+        secret = conf["AUTH_SECRET"]
+        authorization = request.headers.get("Authorization")
 
         if authorization is not None:
             parts = authorization.strip().split()
 
-            if parts[0].lower() != 'bearer':
-                raise web.HTTPUnauthorized(reason='Unsupported auth type.')
+            if parts[0].lower() != "bearer":
+                raise web.HTTPUnauthorized(reason="Unsupported auth type.")
             elif len(parts) == 1:
-                raise web.HTTPUnauthorized(reason='Token missing.')
+                raise web.HTTPUnauthorized(reason="Token missing.")
             elif len(parts) > 2:
-                raise web.HTTPUnauthorized(reason='Token contains spaces.')
+                raise web.HTTPUnauthorized(reason="Token contains spaces.")
 
             try:
-                request['auth'] = jwt.decode(parts[1], secret)
+                request["auth"] = jwt.decode(parts[1], secret)
             except jwt.JWTError:
-                raise web.HTTPUnauthorized(reason='passed token is invalid')
+                raise web.HTTPUnauthorized(reason="passed token is invalid")
         else:
-            request['auth'] = None
+            request["auth"] = None
 
         return await handler(request)
+
     return _auth

--- a/xsnippet/api/resource.py
+++ b/xsnippet/api/resource.py
@@ -47,12 +47,10 @@ class Resource(web.View):
     """
 
     _encoders = {
-        'application/json': functools.partial(json.dumps, cls=_JSONEncoder),
+        "application/json": functools.partial(json.dumps, cls=_JSONEncoder)
     }
 
-    _decoders = {
-        'application/json': json.loads,
-    }
+    _decoders = {"application/json": json.loads}
 
     def __await__(self):
         return self._poor_asyncio_api().__await__()
@@ -63,18 +61,18 @@ class Resource(web.View):
         # of this middleware. Hence, we monkey patch the instance and add a new
         # async method that would de-serialize income payload according to HTTP
         # content negotiation rules.
-        setattr(self.request.__class__, 'get_data', self._get_data())
+        setattr(self.request.__class__, "get_data", self._get_data())
 
         try:
             # TODO: do not access internal method of parent class
             response = await super(Resource, self)._iter()
 
         except exceptions.SnippetNotFound as exc:
-            error = {'message': str(exc)}
+            error = {"message": str(exc)}
             return self._make_response(error, None, 404)
 
         except web.HTTPError as exc:
-            error = {'message': str(exc)}
+            error = {"message": str(exc)}
             return self._make_response(error, None, exc.status_code)
 
         status_code = 200
@@ -111,8 +109,7 @@ class Resource(web.View):
             # According to HTTP standard, 'Accept' header may show up multiple
             # times in the request. So let's join them before passing to parser
             # so we call parser only once.
-            ','.join(self.request.headers.getall(hdrs.ACCEPT, ['*/*'])),
-
+            ",".join(self.request.headers.getall(hdrs.ACCEPT, ["*/*"])),
             # A handful wrapper to choose a best match with one method.
             werkzeug.MIMEAccept,
         )
@@ -143,7 +140,8 @@ class Resource(web.View):
             # to parse headers, as some mime types may contain parameters and
             # we need to strip them out.
             content_type, _ = cgi.parse_header(
-                self.headers.get(hdrs.CONTENT_TYPE, next(iter(decoders))))
+                self.headers.get(hdrs.CONTENT_TYPE, next(iter(decoders)))
+            )
 
             if content_type in decoders:
                 decode = decoders[content_type]
@@ -153,7 +151,9 @@ class Resource(web.View):
                     return decode(text)
                 except Exception as exc:
                     raise web.HTTPBadRequest(
-                        reason='Malformed %s payload: %s' % (content_type, exc))
+                        reason="Malformed %s payload: %s" % (content_type, exc)
+                    )
 
             raise web.HTTPUnsupportedMediaType()
+
         return impl

--- a/xsnippet/api/resources/__init__.py
+++ b/xsnippet/api/resources/__init__.py
@@ -12,8 +12,4 @@ from .snippets import Snippet, Snippets
 from .syntaxes import Syntaxes
 
 
-__all__ = [
-    'Snippet',
-    'Snippets',
-    'Syntaxes'
-]
+__all__ = ["Snippet", "Snippets", "Syntaxes"]

--- a/xsnippet/api/resources/misc.py
+++ b/xsnippet/api/resources/misc.py
@@ -27,8 +27,8 @@ def cerberus_errors_to_str(errors):
     parts = []
     for name, reasons in errors.items():
         for reason in reasons:
-            parts.append('`%s` - %s' % (name, reason))
-    return ', '.join(parts)
+            parts.append("`%s` - %s" % (name, reason))
+    return ", ".join(parts)
 
 
 def try_int(value, base=10):

--- a/xsnippet/api/resources/snippets.py
+++ b/xsnippet/api/resources/snippets.py
@@ -20,46 +20,50 @@ from .. import resource, services
 
 
 def _get_id(resource):
-    v = cerberus.Validator({
-        'id': {'type': 'integer', 'min': 1, 'coerce': try_int},
-    })
+    v = cerberus.Validator(
+        {"id": {"type": "integer", "min": 1, "coerce": try_int}}
+    )
 
     if not v.validate(dict(resource.request.match_info)):
-        reason = '%s.' % cerberus_errors_to_str(v.errors)
+        reason = "%s." % cerberus_errors_to_str(v.errors)
         raise web.HTTPBadRequest(reason=reason)
 
-    return int(resource.request.match_info['id'])
+    return int(resource.request.match_info["id"])
 
 
-@picobox.pass_('conf')
+@picobox.pass_("conf")
 async def _write(resource, service_fn, *, status, conf):
-    v = cerberus.Validator({
-        'id': {'type': 'integer', 'readonly': True},
-        'title': {'type': 'string'},
-        'content': {'type': 'string', 'required': True, 'empty': False},
-        'syntax': {'type': 'string'},
-        'tags': {'type': 'list',
-                 'schema': {'type': 'string', 'regex': r'[\w_-]+'}},
-        'created_at': {'type': 'datetime', 'readonly': True},
-        'updated_at': {'type': 'datetime', 'readonly': True},
-    })
+    v = cerberus.Validator(
+        {
+            "id": {"type": "integer", "readonly": True},
+            "title": {"type": "string"},
+            "content": {"type": "string", "required": True, "empty": False},
+            "syntax": {"type": "string"},
+            "tags": {
+                "type": "list",
+                "schema": {"type": "string", "regex": r"[\w_-]+"},
+            },
+            "created_at": {"type": "datetime", "readonly": True},
+            "updated_at": {"type": "datetime", "readonly": True},
+        }
+    )
 
     snippet = await resource.request.get_data()
-    syntaxes = conf['SNIPPET_SYNTAXES']
+    syntaxes = conf["SNIPPET_SYNTAXES"]
 
     # If 'snippet:syntaxes' option is not empty, we need to ensure that
     # only specified syntaxes are allowed.
     if syntaxes:
-        v.schema['syntax']['allowed'] = syntaxes
+        v.schema["syntax"]["allowed"] = syntaxes
 
     # In case of PATCH required attributes must become optional, since
     # the operation updates the entity partially and we assume all
     # constraints are satisfied in the database.
-    is_patch = resource.request.method.lower() == 'patch'
+    is_patch = resource.request.method.lower() == "patch"
 
     if not v.validate(snippet, update=is_patch):
         error = cerberus_errors_to_str(v.errors)
-        raise web.HTTPBadRequest(reason='%s.' % error)
+        raise web.HTTPBadRequest(reason="%s." % error)
 
     written = await service_fn(snippet)
     return written, status
@@ -71,10 +75,9 @@ async def _read(resource, service_fn, *, status):
 
 
 class Snippet(resource.Resource):
-
     def checkpermissions(fn):
         @functools.wraps(fn)
-        @picobox.pass_('conf')
+        @picobox.pass_("conf")
         async def _wrapper(self, conf, *args, **kwargs):
             # So far there's no way to check user's permissions as we don't
             # track users and snippets' owners. However, we do support methods
@@ -82,9 +85,10 @@ class Snippet(resource.Resource):
             # public but can be tested. That's why we check for a fake flag in
             # conf object that can be set in tests in order to test existing
             # functionality.
-            if not conf.get('_SUDO', False):
-                raise web.HTTPForbidden(reason='Not yet. :)')
+            if not conf.get("_SUDO", False):
+                raise web.HTTPForbidden(reason="Not yet. :)")
             return await fn(self, *args, **kwargs)
+
         return _wrapper
 
     async def get(self):
@@ -97,7 +101,7 @@ class Snippet(resource.Resource):
     @checkpermissions
     async def put(self):
         async def service_fn(snippet):
-            snippet['id'] = _get_id(self)
+            snippet["id"] = _get_id(self)
             return await services.Snippet().replace(snippet)
 
         return await _write(self, service_fn, status=200)
@@ -105,7 +109,7 @@ class Snippet(resource.Resource):
     @checkpermissions
     async def patch(self):
         async def service_fn(snippet):
-            snippet['id'] = _get_id(self)
+            snippet["id"] = _get_id(self)
             return await services.Snippet().update(snippet)
 
         return await _write(self, service_fn, status=200)
@@ -113,23 +117,21 @@ class Snippet(resource.Resource):
 
 def _build_url_from_marker(request, marker=None, limit=None):
     # take into account, that we might be running behind a reverse proxy
-    host = request.headers.get('Host', request.url.host).split(':')[0]
-    proto = request.headers.get('X-Forwarded-Proto', request.scheme)
+    host = request.headers.get("Host", request.url.host).split(":")[0]
+    proto = request.headers.get("X-Forwarded-Proto", request.scheme)
 
     # drop the previous values of limit and marker
     new_query = request.url.query.copy()
-    new_query.pop('limit', None)
-    new_query.pop('marker', None)
+    new_query.pop("limit", None)
+    new_query.pop("marker", None)
 
     # and replace them with new ones (if necessary for the given page)
     if limit:
-        new_query['limit'] = limit
+        new_query["limit"] = limit
     if marker:
-        new_query['marker'] = marker
+        new_query["marker"] = marker
 
-    return request.url.with_scheme(proto) \
-                      .with_host(host) \
-                      .with_query(new_query)
+    return request.url.with_scheme(proto).with_host(host).with_query(new_query)
 
 
 def _build_link_header(request, current_page, previous_page, limit):
@@ -141,7 +143,7 @@ def _build_link_header(request, current_page, previous_page, limit):
 
     # only render a link, if there more items after the current page
     if len(current_page) > limit:
-        marker = current_page[:limit][-1]['id']
+        marker = current_page[:limit][-1]["id"]
         url = _build_url_from_marker(request, marker=marker, limit=limit)
 
         links.append('<%s>; rel="next"' % url)
@@ -153,65 +155,56 @@ def _build_link_header(request, current_page, previous_page, limit):
         if len(previous_page) == limit:
             marker = None
         else:
-            marker = previous_page[-1]['id']
+            marker = previous_page[-1]["id"]
         url = _build_url_from_marker(request, marker=marker, limit=limit)
 
         links.append('<%s>; rel="prev"' % url)
 
-    return ', '.join(links)
+    return ", ".join(links)
 
 
 class Snippets(resource.Resource):
-
-    @picobox.pass_('conf')
+    @picobox.pass_("conf")
     async def get(self, conf):
-        v = cerberus.Validator({
-            'limit': {
-                'type': 'integer',
-                'min': 1,
-                'max': 20,
-                'coerce': try_int,
-            },
-            'marker': {
-                'type': 'integer',
-                'min': 1,
-                'coerce': try_int,
-            },
-            'title': {
-                'type': 'string',
-                'empty': False,
-            },
-            'tag': {
-                'type': 'string',
-                'regex': r'[\w_-]+',
-            },
-            'syntax': {
-                'type': 'string',
-            },
-        })
+        v = cerberus.Validator(
+            {
+                "limit": {
+                    "type": "integer",
+                    "min": 1,
+                    "max": 20,
+                    "coerce": try_int,
+                },
+                "marker": {"type": "integer", "min": 1, "coerce": try_int},
+                "title": {"type": "string", "empty": False},
+                "tag": {"type": "string", "regex": r"[\w_-]+"},
+                "syntax": {"type": "string"},
+            }
+        )
 
-        syntaxes = conf['SNIPPET_SYNTAXES']
+        syntaxes = conf["SNIPPET_SYNTAXES"]
 
         # If 'snippet:syntaxes' option is not empty, we need to ensure that
         # only specified syntaxes are allowed.
         if syntaxes:
-            v.schema['syntax']['allowed'] = syntaxes
+            v.schema["syntax"]["allowed"] = syntaxes
 
         if not v.validate(dict(self.request.query)):
-            error = '%s.' % cerberus_errors_to_str(v.errors)
+            error = "%s." % cerberus_errors_to_str(v.errors)
             raise web.HTTPBadRequest(reason=error)
 
         # It's safe to have type cast here since those query parameters
         # are guaranteed to be integer, thanks to validation above.
-        limit = int(self.request.query.get('limit', 20))
-        marker = int(self.request.query.get('marker', 0))
-        title = self.request.query.get('title')
-        tag = self.request.query.get('tag')
-        syntax = self.request.query.get('syntax')
+        limit = int(self.request.query.get("limit", 20))
+        marker = int(self.request.query.get("marker", 0))
+        title = self.request.query.get("title")
+        tag = self.request.query.get("tag")
+        syntax = self.request.query.get("syntax")
 
         # actual snippets to be returned
         current_page = await services.Snippet().get(
-            title=title, tag=tag, syntax=syntax,
+            title=title,
+            tag=tag,
+            syntax=syntax,
             # read one more to know if there is next page
             limit=limit + 1,
             marker=marker,
@@ -220,11 +213,13 @@ class Snippets(resource.Resource):
         # only needed to render a link to the previous page
         if marker:
             previous_page = await services.Snippet().get(
-                title=title, tag=tag, syntax=syntax,
+                title=title,
+                tag=tag,
+                syntax=syntax,
                 # read one more to know if there is prev page
                 limit=limit + 1,
                 marker=marker,
-                direction='backward'
+                direction="backward",
             )
         else:
             # we are at the very beginning of the list - no prev page
@@ -235,10 +230,8 @@ class Snippets(resource.Resource):
             current_page[:limit],
             200,
             {
-                'Link': _build_link_header(
-                    self.request,
-                    current_page, previous_page,
-                    limit=limit,
+                "Link": _build_link_header(
+                    self.request, current_page, previous_page, limit=limit
                 )
             },
         )

--- a/xsnippet/api/resources/syntaxes.py
+++ b/xsnippet/api/resources/syntaxes.py
@@ -15,7 +15,6 @@ from .. import resource
 
 
 class Syntaxes(resource.Resource):
-
-    @picobox.pass_('conf')
+    @picobox.pass_("conf")
     async def get(self, conf):
-        return conf['SNIPPET_SYNTAXES']
+        return conf["SNIPPET_SYNTAXES"]

--- a/xsnippet/api/routes.py
+++ b/xsnippet/api/routes.py
@@ -6,15 +6,14 @@ from . import resources
 
 
 v1 = [
-    web.route('*', '/v1/snippets', resources.Snippets),
-    web.route('*', '/v1/snippets/{id}', resources.Snippet),
-    web.route('*', '/v1/syntaxes', resources.Syntaxes),
-
+    web.route("*", "/v1/snippets", resources.Snippets),
+    web.route("*", "/v1/snippets/{id}", resources.Snippet),
+    web.route("*", "/v1/syntaxes", resources.Syntaxes),
     # These routes are what we had before during era of API versioning through
     # HTTP header. Nowadays we prefer versioning through HTTP URI, but we want
     # to be good guys and provide these routes for a while and avoid breaking
     # the world.
-    web.route('*', '/snippets', resources.Snippets),
-    web.route('*', '/snippets/{id}', resources.Snippet),
-    web.route('*', '/syntaxes', resources.Syntaxes),
+    web.route("*", "/snippets", resources.Snippets),
+    web.route("*", "/snippets/{id}", resources.Snippet),
+    web.route("*", "/syntaxes", resources.Syntaxes),
 ]

--- a/xsnippet/api/services/__init__.py
+++ b/xsnippet/api/services/__init__.py
@@ -9,6 +9,4 @@
 from .snippet import Snippet
 
 
-__all__ = [
-    'Snippet',
-]
+__all__ = ["Snippet"]

--- a/xsnippet/api/services/snippet.py
+++ b/xsnippet/api/services/snippet.py
@@ -22,29 +22,23 @@ from .. import exceptions
 class Snippet:
 
     _pagination = {
-        'forward': {
-            'filters': {
-                'created_at': '$lte',
-                '_id': '$lt',
+        "forward": {
+            "filters": {"created_at": "$lte", "_id": "$lt"},
+            "sort": {
+                "created_at": pymongo.DESCENDING,
+                "_id": pymongo.DESCENDING,
             },
-            'sort': {
-                'created_at': pymongo.DESCENDING,
-                '_id': pymongo.DESCENDING,
-            }
         },
-        'backward': {
-            'filters': {
-                'created_at': '$gte',
-                '_id': '$gte',
+        "backward": {
+            "filters": {"created_at": "$gte", "_id": "$gte"},
+            "sort": {
+                "created_at": pymongo.ASCENDING,
+                "_id": pymongo.ASCENDING,
             },
-            'sort': {
-                'created_at': pymongo.ASCENDING,
-                '_id': pymongo.ASCENDING,
-            }
         },
     }
 
-    @picobox.pass_('database')
+    @picobox.pass_("database")
     def __init__(self, database):
         self.db = database
 
@@ -52,80 +46,91 @@ class Snippet:
         now = datetime.datetime.utcnow().replace(microsecond=0)
 
         snippet = self._normalize(snippet)
-        snippet['changesets'] = [
-            {
-                'content': snippet.pop('content'),
-                'created_at': now,
-            },
+        snippet["changesets"] = [
+            {"content": snippet.pop("content"), "created_at": now}
         ]
-        snippet['created_at'] = now
-        snippet['updated_at'] = now
+        snippet["created_at"] = now
+        snippet["updated_at"] = now
 
-        resolved = await self.db['_autoincrement_ids'].find_one_and_update(
-            {'_id': 'snippets'},
-            update={'$inc': {'next': 1}},
+        resolved = await self.db["_autoincrement_ids"].find_one_and_update(
+            {"_id": "snippets"},
+            update={"$inc": {"next": 1}},
             upsert=True,
-            new=True)
-        snippet['_id'] = resolved['next']
+            new=True,
+        )
+        snippet["_id"] = resolved["next"]
 
         await self.db.snippets.insert_one(snippet)
-        snippet['id'] = snippet.pop('_id')
-        snippet['content'] = snippet.pop('changesets', [])[0]['content']
+        snippet["id"] = snippet.pop("_id")
+        snippet["content"] = snippet.pop("changesets", [])[0]["content"]
 
         return snippet
 
     async def update(self, snippet):
         now = datetime.datetime.utcnow().replace(microsecond=0)
-        snippet['updated_at'] = now
+        snippet["updated_at"] = now
 
-        parameters = {'$set': snippet}
+        parameters = {"$set": snippet}
 
-        if snippet.get('content'):
-            parameters['$push'] = {
-                'changesets': {
-                    'content': snippet.pop('content'),
-                    'created_at': now,
+        if snippet.get("content"):
+            parameters["$push"] = {
+                "changesets": {
+                    "content": snippet.pop("content"),
+                    "created_at": now,
                 }
             }
 
         result = await self.db.snippets.update_one(
-            {'_id': snippet['id']},
-            parameters,
+            {"_id": snippet["id"]}, parameters
         )
 
         if result.matched_count == 0:
             raise exceptions.SnippetNotFound(
-                'Sorry, cannot find the requested snippet.')
+                "Sorry, cannot find the requested snippet."
+            )
 
-        return await self.get_one(snippet['id'])
+        return await self.get_one(snippet["id"])
 
     async def replace(self, snippet):
         return await self.update(self._normalize(snippet))
 
-    async def get(self, *, title=None, tag=None, syntax=None, limit=100,
-                  marker=None, direction='forward'):
+    async def get(
+        self,
+        *,
+        title=None,
+        tag=None,
+        syntax=None,
+        limit=100,
+        marker=None,
+        direction="forward"
+    ):
         condition = {}
 
-        sort = self._pagination[direction]['sort']
-        filters = self._pagination[direction]['filters']
+        sort = self._pagination[direction]["sort"]
+        filters = self._pagination[direction]["filters"]
 
         if title is not None:
-            condition['title'] = {'$regex': '^' + re.escape(title) + '.*'}
+            condition["title"] = {"$regex": "^" + re.escape(title) + ".*"}
         if tag is not None:
-            condition['tags'] = tag
+            condition["tags"] = tag
         if syntax is not None:
-            condition['syntax'] = syntax
+            condition["syntax"] = syntax
 
         if marker:
-            specimen = await self.db.snippets.find_one({'_id': marker})
+            specimen = await self.db.snippets.find_one({"_id": marker})
             if not specimen:
                 raise exceptions.SnippetNotFound(
-                    'Sorry, cannot complete the request since `marker` '
-                    'points to a nonexistent snippet.')
+                    "Sorry, cannot complete the request since `marker` "
+                    "points to a nonexistent snippet."
+                )
 
-            condition['$and'] = [
-                {'created_at': {filters['created_at']: specimen['created_at']}},
-                {'_id': {filters['_id']: specimen['_id']}},
+            condition["$and"] = [
+                {
+                    "created_at": {
+                        filters["created_at"]: specimen["created_at"]
+                    }
+                },
+                {"_id": {filters["_id"]: specimen["_id"]}},
             ]
 
         # use a compound sorting key (created_at, _id) to avoid the ambiguity
@@ -134,38 +139,35 @@ class Snippet:
         # corresponding index on (created_at, _id), that ensures this operation
         # can be performed efficiently (mongo does not need to sort documents
         # at all - it just walks over the btree index in chosen order)
-        query = self.db.snippets.find(condition).sort([
-            ('created_at', sort['created_at']),
-            ('_id', sort['_id']),
-        ])
+        query = self.db.snippets.find(condition).sort(
+            [("created_at", sort["created_at"]), ("_id", sort["_id"])]
+        )
 
         snippets = await query.limit(limit).to_list(None)
         for snippet in snippets:
-            snippet['id'] = snippet.pop('_id')
-            snippet['content'] = snippet.pop('changesets', [])[-1]['content']
+            snippet["id"] = snippet.pop("_id")
+            snippet["content"] = snippet.pop("changesets", [])[-1]["content"]
         return snippets
 
     async def get_one(self, id):
-        snippet = await self.db.snippets.find_one({'_id': id})
+        snippet = await self.db.snippets.find_one({"_id": id})
 
         if snippet is None:
             raise exceptions.SnippetNotFound(
-                'Sorry, cannot find the requested snippet.')
+                "Sorry, cannot find the requested snippet."
+            )
 
-        snippet['id'] = snippet.pop('_id')
-        snippet['content'] = snippet.pop('changesets', [])[-1]['content']
+        snippet["id"] = snippet.pop("_id")
+        snippet["content"] = snippet.pop("changesets", [])[-1]["content"]
         return snippet
 
     async def delete(self, id):
-        result = await self.db.snippets.delete_one({'_id': id})
+        result = await self.db.snippets.delete_one({"_id": id})
         if result.deleted_count == 0:
             raise exceptions.SnippetNotFound(
-                'Sorry, cannot find the requested snippet.')
+                "Sorry, cannot find the requested snippet."
+            )
 
     def _normalize(self, snippet):
-        rv = dict({
-            'title': None,
-            'syntax': None,
-            'tags': [],
-        }, **snippet)
+        rv = dict({"title": None, "syntax": None, "tags": []}, **snippet)
         return rv


### PR DESCRIPTION
By using Black, we agree to cede control over minutiae of
hand-formatting. In return, Black gives us speed, determinism, and
freedom from pycodestyle nagging about formatting.

Black makes code review faster by producing the smallest diffs possible.
Blackened code looks the same regardless of the project we’re reading.
Formatting becomes transparent after a while and we can focus on the
content instead.