### PR TITLE
Parametrize a set of supported syntaxes on start

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -1,5 +1,40 @@
+use std::collections::HashSet;
+use std::error::Error;
+
 use super::routes;
 
-pub fn create_app() -> rocket::Rocket {
-    rocket::ignite().mount("/v1", routes![routes::syntaxes::get_syntaxes])
+#[derive(Debug)]
+pub struct Config {
+    /// Keeps a set of supported syntaxes. When set, RESTful API rejects
+    /// snippets with *unsupported* syntaxes. Normally this set must be
+    /// kept in sync with a set of supported syntaxes in XSnippet Web in
+    /// order to ensure that the web part can properly syntax-highlight
+    /// snippets.
+    pub syntaxes: Option<HashSet<String>>,
+}
+
+/// Create and return a Rocket application instance.
+///
+/// # Errors
+///
+/// Returns `Err(rocket::config::ConfigError)` if configuration supplied
+/// cannot be parsed or invalid.
+pub fn create_app() -> Result<rocket::Rocket, Box<dyn Error>> {
+    let app = rocket::ignite();
+
+    let syntaxes = app.config().get_slice("syntaxes");
+    let syntaxes = match syntaxes {
+        Ok(syntaxes) => Some(
+            syntaxes
+                .iter()
+                .map(|v| v.clone().try_into::<String>())
+                .collect::<Result<HashSet<_>, _>>()?,
+        ),
+        Err(rocket::config::ConfigError::Missing(_)) => None,
+        Err(err) => return Err(Box::new(err)),
+    };
+
+    Ok(app
+        .manage(Config { syntaxes: syntaxes })
+        .mount("/v1", routes![routes::syntaxes::get_syntaxes]))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,12 @@ mod application;
 mod routes;
 
 fn main() {
-    let app = application::create_app();
+    let app = match application::create_app() {
+        Ok(app) => app,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            std::process::exit(1);
+        }
+    };
     app.launch();
 }

--- a/src/routes/syntaxes.rs
+++ b/src/routes/syntaxes.rs
@@ -1,6 +1,12 @@
+use rocket::State;
 use rocket_contrib::json::JsonValue;
 
+use crate::application::Config;
+
 #[get("/syntaxes")]
-pub fn get_syntaxes() -> JsonValue {
-    json!(["rust"])
+pub fn get_syntaxes(config: State<Config>) -> JsonValue {
+    // This is a static route that simply returns a list of supported syntaxes.
+    // Normally XSnippet API clients must inspect these values and use them with
+    // submitted snippets.
+    json!(config.syntaxes)
 }


### PR DESCRIPTION
Dealing with snippets, XSnippet API has a notion of syntaxes, one may consider using to highlight the snippet on the web or perform some actions in other clients. These syntaxes may differ based on supported syntaxes in XSnippet Web, or needs of others when this service is ran on premises.

This patch adds parametrization via Rocket's built-in facilities, such as `Rocket.toml` or `ROCKET_SYNTAXES` environment variable. The variable must be a list of strings.

```
$ ROCKET_SYNTAXES=["rust", "python"] cargo run
```

By default, no syntaxes are used.