### PR TITLE
The initial implementation of the storage layer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
           sudo -u postgres createuser -s devel
           sudo -u postgres createdb -O devel devel
           sudo -u postgres psql -c "ALTER USER devel PASSWORD 'devel';" devel
-          echo '::set-env name=DATABASE_URL::postgres://devel:devel@localhost/devel'
+          echo '::set-env name=ROCKET_DATABASE_URL::postgres://devel:devel@localhost/devel'
 
       - name: Start PostgreSQL and create a database (MacOS)
         if: runner.os == 'macOS'
@@ -81,7 +81,7 @@ jobs:
           /usr/local/opt/postgres/bin/createuser -s devel
           /usr/local/opt/postgres/bin/createdb -O devel devel
           /usr/local/opt/postgres/bin/psql -c "ALTER USER devel PASSWORD 'devel';" devel
-          echo '::set-env name=DATABASE_URL::postgres://devel:devel@localhost/devel'
+          echo '::set-env name=ROCKET_DATABASE_URL::postgres://devel:devel@localhost/devel'
 
       - name: Start PostgreSQL and create a database (Windows)
         if: runner.os == 'Windows'
@@ -95,7 +95,7 @@ jobs:
           "C:\Program Files\PostgreSQL\12\bin\createuser" -s devel
           "C:\Program Files\PostgreSQL\12\bin\createdb" -O devel devel
           "C:\Program Files\PostgreSQL\12\bin\psql" -c "ALTER USER devel PASSWORD 'devel';" devel
-          echo '::set-env name=DATABASE_URL::postgres://devel:devel@localhost/devel'
+          echo '::set-env name=ROCKET_DATABASE_URL::postgres://devel:devel@localhost/devel'
 
       - name: Install Alembic and psycopg2
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "cookie"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,8 +228,10 @@ checksum = "3e2de9deab977a153492a1468d1b1c0662c1cf39e5ea87d0c060ecd59ef18d8c"
 dependencies = [
  "bitflags",
  "byteorder",
+ "chrono",
  "diesel_derives",
  "pq-sys",
+ "r2d2",
 ]
 
 [[package]]
@@ -436,6 +447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +494,15 @@ name = "libc"
 version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -625,6 +651,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "pear"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +769,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2 1.0.19",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log 0.4.11",
+ "parking_lot",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -852,6 +915,21 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -1131,6 +1209,7 @@ version = "5.0.0"
 dependencies = [
  "chrono",
  "diesel",
+ "rand",
  "rocket",
  "rocket_contrib",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 
 [dependencies]
 chrono = "0.4.13"
-diesel = { version = "1.4.5", features = ["postgres"] }
+diesel = { version = "1.4.5", features = ["chrono", "postgres", "r2d2"] }
+rand = "0.7.3"
 rocket = "0.4.5"
 rocket_contrib = {version = "0.4.5", features = ["json"]}

--- a/src/application.rs
+++ b/src/application.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::error::Error;
 
 use super::routes;
+use super::storage::{SqlStorage, Storage};
 
 #[derive(Debug)]
 pub struct Config {
@@ -34,7 +35,14 @@ pub fn create_app() -> Result<rocket::Rocket, Box<dyn Error>> {
         Err(err) => return Err(Box::new(err)),
     };
 
+    let database_url = match app.config().get_string("database_url") {
+        Ok(database_url) => database_url,
+        Err(err) => return Err(Box::new(err)),
+    };
+    let storage: Box<dyn Storage> = Box::new(SqlStorage::new(&database_url)?);
+
     Ok(app
         .manage(Config { syntaxes })
+        .manage(storage)
         .mount("/v1", routes![routes::syntaxes::get_syntaxes]))
 }

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -1,0 +1,63 @@
+use std::error;
+use std::fmt;
+
+/// All errors that can be returned by the storage layer wrapped into a single
+/// enum type for convinience.
+#[derive(Debug)]
+pub enum StorageError {
+    /// Snippet with this id already exists in the database
+    Duplicate { id: String },
+    /// Snippet with this id can't be found
+    NotFound { id: String },
+    /// All other errors that can't be handled by the storage layer
+    InternalError(Box<dyn error::Error>),
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            StorageError::Duplicate { id } => write!(f, "Snippet with id `{}` already exists", id),
+            StorageError::NotFound { id } => write!(f, "Snippet with id `{}` is not found", id),
+            StorageError::InternalError(e) => write!(f, "Internal error: `{}`", e),
+        }
+    }
+}
+
+// this is not strictly required, but allows for wrapping a StorageError
+// instance into a Box<dyn Error> if needed. Error's only requirement is for
+// a type to implement Debug + Display
+impl error::Error for StorageError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(
+            "Snippet with id `spam` already exists",
+            format!(
+                "{}",
+                StorageError::Duplicate {
+                    id: "spam".to_string()
+                }
+            )
+        );
+
+        assert_eq!(
+            "Snippet with id `eggs` is not found",
+            format!(
+                "{}",
+                StorageError::NotFound {
+                    id: "eggs".to_string()
+                }
+            )
+        );
+
+        let error = "foo".parse::<f32>().err().unwrap();
+        assert_eq!(
+            "Internal error: `invalid float literal`",
+            format!("{}", StorageError::InternalError(Box::new(error)))
+        );
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,1 +1,27 @@
-pub mod sql;
+mod errors;
+mod models;
+mod sql;
+
+pub use errors::StorageError;
+pub use models::{Changeset, Snippet};
+pub use sql::SqlStorage;
+
+/// CRUD interface for storing/loading snippets from a persistent storage.
+///
+/// Types implementing this trait are required to be both Send and Sync, so
+/// that their instances can be safely shared between multiple threads.
+pub trait Storage: Send + Sync {
+    /// Save the state of the given snippet to the persistent storage.
+    fn create(&self, snippet: &Snippet) -> Result<Snippet, StorageError>;
+
+    /// Returns the snippet uniquely identified by a given id (a slug or a
+    /// legacy numeric id)
+    fn get(&self, id: &str) -> Result<Snippet, StorageError>;
+
+    /// Update the state of the given snippet in the persistent storage
+    fn update(&self, snippet: &Snippet) -> Result<Snippet, StorageError>;
+
+    /// Delete the snippet uniquely identified by a given id (a slug or a legacy
+    /// numeric id)
+    fn delete(&self, id: &str) -> Result<(), StorageError>;
+}

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -1,0 +1,261 @@
+use std::iter;
+
+use chrono::{DateTime, Utc};
+use rand::Rng;
+
+const DEFAULT_SLUG_LENGTH: usize = 8;
+
+/// A code snippet
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct Snippet {
+    /// Slug that uniquely identifies the snippet
+    pub id: String,
+    /// Snippet title. None means that the title was not specified at snippet
+    /// creation time
+    pub title: Option<String>,
+    /// Snippet syntax. None means that the syntax was not specified at snippet
+    /// creation time
+    pub syntax: Option<String>,
+    /// List of revisions. The snippet content is the content of the most recent
+    /// revision. Revisions are sorted by the version number in the
+    /// ascending order.
+    pub changesets: Vec<Changeset>,
+    /// List of tags attached to the snippet
+    pub tags: Vec<String>,
+    /// Timestamp of when the snippet was created
+    pub created_at: Option<DateTime<Utc>>,
+    /// Timestamp of when the snippet was last modified. Defaults to creation
+    /// time
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl Snippet {
+    /// Create a new Snippet.
+    pub fn new(
+        title: Option<String>,
+        syntax: Option<String>,
+        changesets: Vec<Changeset>,
+        tags: Vec<String>,
+    ) -> Self {
+        let mut snippet = Snippet::default();
+        snippet.id = Snippet::random_id(DEFAULT_SLUG_LENGTH);
+        snippet.title = title;
+        snippet.syntax = syntax;
+        snippet.changesets = changesets;
+        snippet.tags = tags;
+
+        snippet
+    }
+
+    /// Generate a random unique snippet identifier (slug).
+    pub fn random_id(length: usize) -> String {
+        let mut rng = rand::thread_rng();
+        iter::repeat_with(|| rng.sample(rand::distributions::Alphanumeric))
+            .take(length)
+            .collect()
+    }
+}
+
+/// A particular snippet revision
+#[derive(Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Changeset {
+    /// Changeset index. Version numbers start from 0 and are incremented by 1
+    pub version: usize,
+    /// Changeset content
+    pub content: String,
+    /// Timestamp of when the changeset was created
+    pub created_at: Option<DateTime<Utc>>,
+    /// Timestamp of when the changeset was last modified. Defaults to creation
+    /// time
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl Changeset {
+    /// Create a new Changeset.
+    pub fn new(version: usize, content: String) -> Self {
+        let mut changeset = Changeset::default();
+        changeset.version = version;
+        changeset.content = content;
+
+        changeset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_snippet() {
+        let snippet = Snippet::default();
+
+        assert_eq!(snippet.id, "");
+        assert_eq!(snippet.title, None);
+        assert_eq!(snippet.syntax, None);
+        assert_eq!(snippet.changesets, vec![] as Vec<Changeset>);
+        assert_eq!(snippet.tags, vec![] as Vec<String>);
+        assert_eq!(snippet.created_at, None);
+        assert_eq!(snippet.updated_at, None);
+    }
+
+    #[test]
+    fn test_new_snippet() {
+        let snippet = Snippet::new(
+            Some("Hello".to_string()),
+            Some("python".to_string()),
+            vec![Changeset::new(0, "print('Hello, World!')".to_string())],
+            vec!["#python".to_string()],
+        );
+
+        assert_eq!(snippet.id.len(), DEFAULT_SLUG_LENGTH);
+        assert_eq!(snippet.title, Some("Hello".to_string()));
+        assert_eq!(snippet.syntax, Some("python".to_string()));
+        assert_eq!(
+            snippet.changesets,
+            vec![Changeset::new(0, "print('Hello, World!')".to_string())]
+        );
+        assert_eq!(snippet.tags, vec!["#python".to_string()]);
+        assert_eq!(snippet.created_at, None);
+        assert_eq!(snippet.updated_at, None);
+    }
+
+    #[test]
+    fn test_snippet_equality() {
+        let reference = Snippet {
+            id: "spam".to_string(),
+            title: Some("Hello".to_string()),
+            syntax: Some("python".to_string()),
+            changesets: vec![Changeset::new(0, "print('Hello, World!')".to_string())],
+            tags: vec!["#python".to_string()],
+            created_at: None,
+            updated_at: None,
+        };
+        let equal = Snippet {
+            id: "spam".to_string(),
+            title: Some("Hello".to_string()),
+            syntax: Some("python".to_string()),
+            changesets: vec![Changeset::new(0, "print('Hello, World!')".to_string())],
+            tags: vec!["#python".to_string()],
+            created_at: None,
+            updated_at: None,
+        };
+        let different_title = Snippet {
+            id: "spam".to_string(),
+            title: None,
+            syntax: Some("python".to_string()),
+            changesets: vec![Changeset::new(0, "print('Hello, World!')".to_string())],
+            tags: vec!["#python".to_string()],
+            created_at: None,
+            updated_at: None,
+        };
+        let different_syntax = Snippet {
+            id: "spam".to_string(),
+            title: Some("Hello".to_string()),
+            syntax: None,
+            changesets: vec![Changeset::new(0, "print('Hello, World!')".to_string())],
+            tags: vec!["#python".to_string()],
+            created_at: None,
+            updated_at: None,
+        };
+        let different_changesets = Snippet {
+            id: "spam".to_string(),
+            title: Some("Hello".to_string()),
+            syntax: None,
+            changesets: vec![Changeset::new(1, "print('Hello, World!')".to_string())],
+            tags: vec!["#python".to_string()],
+            created_at: None,
+            updated_at: None,
+        };
+        let different_tags = Snippet {
+            id: "spam".to_string(),
+            title: Some("Hello".to_string()),
+            syntax: Some("python".to_string()),
+            changesets: vec![Changeset::new(0, "print('Hello, World!')".to_string())],
+            tags: vec![],
+            created_at: None,
+            updated_at: None,
+        };
+
+        assert_eq!(reference, equal);
+        assert_eq!(equal, reference);
+
+        assert_ne!(reference, different_title);
+        assert_ne!(reference, different_syntax);
+        assert_ne!(reference, different_changesets);
+        assert_ne!(reference, different_tags);
+        assert_ne!(different_title, reference);
+        assert_ne!(different_syntax, reference);
+        assert_ne!(different_changesets, reference);
+        assert_ne!(different_tags, reference);
+    }
+
+    #[test]
+    fn test_random_id() {
+        let iterations = 10000;
+        let length = 7;
+
+        // verify that ids are sufficiently random
+        let generated_ids: std::collections::HashSet<_> =
+            std::iter::repeat_with(|| Snippet::random_id(length))
+                .take(iterations)
+                .collect();
+        assert_eq!(generated_ids.len(), iterations);
+
+        // verify that ids are generated with the specified length and only
+        // contain characters from the 'a'-'z', 'A'-'Z', '0'-'9' ranges
+        for id in generated_ids.iter() {
+            assert_eq!(id.len(), length);
+            assert!(
+                id.chars().all(|c| c.is_ascii_alphanumeric()),
+                id.to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_changeset() {
+        let changeset = Changeset::default();
+
+        assert_eq!(changeset.version, 0);
+        assert_eq!(changeset.content, "");
+        assert_eq!(changeset.created_at, None);
+        assert_eq!(changeset.updated_at, None);
+    }
+
+    #[test]
+    fn test_new_changeset() {
+        let changeset = Changeset::new(42, "print('Hello, World!')".to_string());
+
+        assert_eq!(changeset.version, 42);
+        assert_eq!(changeset.content, "print('Hello, World!')".to_string());
+        assert_eq!(changeset.created_at, None);
+        assert_eq!(changeset.updated_at, None);
+    }
+
+    #[test]
+    fn test_changeset_ordering() {
+        let changeset1 = Changeset::new(42, "print('Hello!')".to_string());
+        let changeset2 = Changeset::new(43, "print('Hello, World!')".to_string());
+
+        assert!(changeset1 < changeset2);
+        assert!(changeset1 <= changeset2);
+        assert!(changeset2 > changeset1);
+        assert!(changeset2 >= changeset1);
+    }
+
+    #[test]
+    fn test_changeset_equality() {
+        let reference = Changeset::new(42, "print('Hello!')".to_string());
+        let equal = Changeset::new(42, "print('Hello!')".to_string());
+        let different_version = Changeset::new(43, "print('Hello!')".to_string());
+        let different_content = Changeset::new(42, "print('Hello, World!')".to_string());
+
+        assert_eq!(reference, equal);
+        assert_eq!(equal, reference);
+
+        assert_ne!(reference, different_version);
+        assert_ne!(reference, different_content);
+        assert_ne!(different_version, reference);
+        assert_ne!(different_content, reference);
+    }
+}

--- a/src/storage/sql/migrations/env.py
+++ b/src/storage/sql/migrations/env.py
@@ -19,7 +19,7 @@ def run_migrations_offline():
     """
 
     context.configure(
-        url=os.environ['DATABASE_URL'],
+        url=os.environ['ROCKET_DATABASE_URL'],
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
     )
@@ -37,7 +37,7 @@ def run_migrations_online():
     """
 
     connectable = create_engine(
-        os.environ['DATABASE_URL'],
+        os.environ['ROCKET_DATABASE_URL'],
         poolclass=pool.NullPool,
     )
     with connectable.connect() as connection:

--- a/src/storage/sql/mod.rs
+++ b/src/storage/sql/mod.rs
@@ -1,1 +1,331 @@
+mod models;
 mod schema;
+
+use std::convert::From;
+
+use diesel::pg::upsert;
+use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool, PoolError};
+use diesel::result::{DatabaseErrorKind, Error::DatabaseError, Error::NotFound};
+
+use super::{errors::StorageError, Snippet, Storage};
+use schema::{changesets, snippets, tags};
+
+/// A Storage implementation which persists snippets' data in a SQL database.
+pub struct SqlStorage {
+    pool: Pool<ConnectionManager<PgConnection>>,
+}
+
+impl SqlStorage {
+    pub fn new(database_url: &str) -> Result<SqlStorage, StorageError> {
+        let manager = ConnectionManager::new(database_url);
+        let pool = Pool::builder().build(manager)?;
+
+        Ok(Self { pool })
+    }
+
+    fn insert_snippet(&self, conn: &PgConnection, snippet: &Snippet) -> Result<i32, StorageError> {
+        let result = diesel::insert_into(snippets::table)
+            .values((
+                snippets::slug.eq(&snippet.id),
+                snippets::title.eq(&snippet.title),
+                snippets::syntax.eq(&snippet.syntax),
+                snippets::created_at.eq(diesel::dsl::now),
+                snippets::updated_at.eq(diesel::dsl::now),
+            ))
+            .returning(snippets::id)
+            .get_result::<i32>(conn);
+
+        match result {
+            Ok(snippet_id) => Ok(snippet_id),
+            Err(DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
+                Err(StorageError::Duplicate {
+                    id: snippet.id.to_owned(),
+                })
+            }
+            Err(e) => Err(StorageError::from(e)),
+        }
+    }
+
+    fn update_snippet(&self, conn: &PgConnection, snippet: &Snippet) -> Result<i32, StorageError> {
+        let result = diesel::update(snippets::table.filter(snippets::slug.eq(&snippet.id)))
+            .set((
+                snippets::title.eq(&snippet.title),
+                snippets::syntax.eq(&snippet.syntax),
+                snippets::updated_at.eq(diesel::dsl::now),
+            ))
+            .returning(snippets::id)
+            .get_result::<i32>(conn);
+
+        match result {
+            Ok(snippet_id) => Ok(snippet_id),
+            Err(NotFound) => Err(StorageError::NotFound {
+                id: snippet.id.to_owned(),
+            }),
+            Err(e) => Err(StorageError::from(e)),
+        }
+    }
+
+    fn upsert_changesets(
+        &self,
+        conn: &PgConnection,
+        snippet_id: i32,
+        snippet: &Snippet,
+    ) -> Result<(), StorageError> {
+        diesel::insert_into(changesets::table)
+            .values(
+                snippet
+                    .changesets
+                    .iter()
+                    .map(|c| {
+                        (
+                            changesets::snippet_id.eq(snippet_id),
+                            changesets::version.eq(c.version as i32),
+                            changesets::content.eq(&c.content),
+                            changesets::created_at.eq(diesel::dsl::now),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .on_conflict((changesets::snippet_id, changesets::version))
+            .do_update()
+            .set((
+                changesets::content.eq(upsert::excluded(changesets::content)),
+                changesets::updated_at.eq(diesel::dsl::now),
+            ))
+            .execute(conn)?;
+
+        Ok(())
+    }
+
+    fn upsert_tags(
+        &self,
+        conn: &PgConnection,
+        snippet_id: i32,
+        snippet: &Snippet,
+    ) -> Result<(), StorageError> {
+        diesel::insert_into(tags::table)
+            .values(
+                snippet
+                    .tags
+                    .iter()
+                    .map(|t| (tags::snippet_id.eq(snippet_id), tags::value.eq(t)))
+                    .collect::<Vec<_>>(),
+            )
+            .on_conflict_do_nothing()
+            .execute(conn)?;
+
+        Ok(())
+    }
+
+    fn trim_removed_tags(
+        &self,
+        conn: &PgConnection,
+        snippet_id: i32,
+        snippet: &Snippet,
+    ) -> Result<(), StorageError> {
+        diesel::delete(
+            tags::table.filter(
+                tags::snippet_id
+                    .eq(snippet_id)
+                    .and(tags::value.ne_all(&snippet.tags)),
+            ),
+        )
+        .execute(conn)?;
+
+        Ok(())
+    }
+}
+
+impl Storage for SqlStorage {
+    fn create(&self, snippet: &Snippet) -> Result<Snippet, StorageError> {
+        let conn = self.pool.get()?;
+        conn.transaction::<_, StorageError, _>(|| {
+            // insert the new snippet row first to get the generated primary key
+            let snippet_id = self.insert_snippet(&conn, snippet)?;
+            // insert the associated changesets
+            self.upsert_changesets(&conn, snippet_id, snippet)?;
+            // insert the associated tags
+            self.upsert_tags(&conn, snippet_id, snippet)?;
+
+            Ok(())
+        })?;
+
+        // reconstruct the created snippet from the state persisted to the database
+        self.get(&snippet.id)
+    }
+
+    fn get(&self, id: &str) -> Result<Snippet, StorageError> {
+        let conn = self.pool.get()?;
+        conn.transaction::<_, StorageError, _>(|| {
+            let result = snippets::table
+                .filter(snippets::slug.eq(id))
+                .get_result::<models::SnippetRow>(&conn);
+            let snippet = match result {
+                Ok(snippet) => snippet,
+                Err(diesel::NotFound) => return Err(StorageError::NotFound { id: id.to_owned() }),
+                Err(e) => return Err(StorageError::from(e)),
+            };
+
+            let changesets = changesets::table
+                .filter(changesets::snippet_id.eq(snippet.id))
+                .get_results::<models::ChangesetRow>(&conn)?;
+            let tags = tags::table
+                .filter(tags::snippet_id.eq(snippet.id))
+                .get_results::<models::TagRow>(&conn)?;
+
+            Ok(Snippet::from((snippet, changesets, tags)))
+        })
+    }
+
+    fn update(&self, snippet: &Snippet) -> Result<Snippet, StorageError> {
+        // load the snippet from the db to check if we need to update anything
+        let persisted_state = self.get(&snippet.id)?;
+        if persisted_state == *snippet {
+            // if not, simply return the current state
+            Ok(persisted_state)
+        } else {
+            // otherwise, potentially update the title and the syntax
+            let conn = self.pool.get()?;
+            conn.transaction::<_, StorageError, _>(|| {
+                let snippet_id = self.update_snippet(&conn, snippet)?;
+                // insert new changesets and tags
+                self.upsert_changesets(&conn, snippet_id, snippet)?;
+                self.upsert_tags(&conn, snippet_id, snippet)?;
+                // and delete the removed tags
+                self.trim_removed_tags(&conn, snippet_id, snippet)?;
+
+                Ok(())
+            })?;
+
+            // reconstruct the created snippet from the state persisted to the database
+            // (e.g. so that updated_at fields are correctly populated)
+            self.get(&snippet.id)
+        }
+    }
+
+    fn delete(&self, id: &str) -> Result<(), StorageError> {
+        // CASCADE on foreign keys will take care of deleting associated changesets and
+        // tags
+        let conn = self.pool.get()?;
+        let deleted_rows =
+            diesel::delete(snippets::table.filter(snippets::slug.eq(id))).execute(&conn)?;
+        if deleted_rows == 0 {
+            Err(StorageError::NotFound { id: id.to_owned() })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// Allow wrapping Diesel errors into StorageError, so that we can distinguish
+// them from other variants of the StorageError enum using pattern matching
+impl From<diesel::result::Error> for StorageError {
+    fn from(error: diesel::result::Error) -> Self {
+        StorageError::InternalError(Box::new(error))
+    }
+}
+
+impl From<diesel::ConnectionError> for StorageError {
+    fn from(error: diesel::ConnectionError) -> Self {
+        StorageError::InternalError(Box::new(error))
+    }
+}
+
+impl From<PoolError> for StorageError {
+    fn from(error: PoolError) -> Self {
+        StorageError::InternalError(Box::new(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use super::super::Changeset;
+
+    /// Compare snippets for equality excluding fields with generated values
+    /// (created_at, updated_at)
+    fn compare_snippets(expected: &Snippet, actual: &Snippet) {
+        assert_eq!(expected.id, actual.id);
+        assert_eq!(expected.title, actual.title);
+        assert_eq!(expected.syntax, actual.syntax);
+        assert_eq!(expected.tags, actual.tags);
+
+        for (expected_changeset, actual_changeset) in
+            expected.changesets.iter().zip(actual.changesets.iter())
+        {
+            assert_eq!(expected_changeset.version, actual_changeset.version);
+            assert_eq!(expected_changeset.content, actual_changeset.content);
+        }
+    }
+
+    #[test]
+    fn smoke() {
+        // This will be properly covered by the higher level tests, so we just want to
+        // do a basic smoke test here. If ROCKET_DATABASE_URL is not set, the
+        // test should be skipped.
+
+        let database_url = match std::env::var("ROCKET_DATABASE_URL") {
+            Ok(database_url) => database_url,
+            Err(_) => return,
+        };
+
+        let reference = Snippet::new(
+            Some("Hello world".to_string()),
+            Some("python".to_string()),
+            vec![
+                Changeset::new(1, "print('Hello')".to_string()),
+                Changeset::new(2, "print('Hello, World!')".to_string()),
+            ],
+            vec!["spam".to_string(), "eggs".to_string()],
+        );
+        let mut updated_reference = Snippet::new(
+            Some("Hello world!".to_string()),
+            Some("python".to_string()),
+            vec![
+                Changeset::new(1, "print('Hello')".to_string()),
+                Changeset::new(2, "print('Hello, World!')".to_string()),
+                Changeset::new(3, "print('Hello!')".to_string()),
+            ],
+            vec!["spam".to_string(), "foo".to_string(), "bar".to_string()],
+        );
+        updated_reference.id = reference.id.clone();
+
+        // create a new SqlStorage instance (creates a DB connection pool internally)
+        let storage: Box<dyn Storage> = Box::new(
+            SqlStorage::new(&database_url).expect("Failed to create a SqlStorage instance"),
+        );
+
+        // create a new snippet from the reference value
+        let new_snippet = storage
+            .create(&reference)
+            .expect("Failed to create a snippet");
+        compare_snippets(&reference, &new_snippet);
+
+        // retrieve the state of the snippet that was just persisted
+        let retrieved_snippet = storage
+            .get(&new_snippet.id)
+            .expect("Failed to retrieve a snippet");
+        // the snippet's state must be exactly the same as the one returned by create()
+        // above, including the value of created_at/updated_at fields
+        assert_eq!(new_snippet, retrieved_snippet);
+
+        // try to update the snippet state somehow
+        let updated_snippet = storage
+            .update(&updated_reference)
+            .expect("Failed to update a snippet");
+        compare_snippets(&updated_reference, &updated_snippet);
+
+        // finally, delete the snippet
+        storage
+            .delete(&new_snippet.id)
+            .expect("Failed to delete a snippet");
+
+        // and verify that it can't be found in the database anymore
+        assert!(match storage.get(&new_snippet.id) {
+            Err(StorageError::NotFound { id }) => id == new_snippet.id,
+            _ => false,
+        });
+    }
+}

--- a/src/storage/sql/models.rs
+++ b/src/storage/sql/models.rs
@@ -1,0 +1,147 @@
+use std::convert::From;
+
+use chrono::{DateTime, Utc};
+
+use crate::storage::models::{Changeset, Snippet};
+
+#[derive(Queryable)]
+pub struct SnippetRow {
+    pub id: i32,
+    pub slug: String,
+    pub title: Option<String>,
+    pub syntax: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Queryable)]
+pub struct ChangesetRow {
+    pub id: i32,
+    pub snippet_id: i32,
+    pub version: i32,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Queryable)]
+pub struct TagRow {
+    pub id: i32,
+    pub snippet_id: i32,
+    pub value: String,
+}
+
+impl From<(SnippetRow, Vec<ChangesetRow>, Vec<TagRow>)> for Snippet {
+    fn from(parts: (SnippetRow, Vec<ChangesetRow>, Vec<TagRow>)) -> Self {
+        let (snippet_row, changeset_rows, tag_rows) = parts;
+
+        let tags: Vec<String> = tag_rows.into_iter().map(|t| t.value).collect();
+        let mut changesets: Vec<Changeset> = changeset_rows
+            .into_iter()
+            .map(
+                |ChangesetRow {
+                     id: _,
+                     snippet_id: _,
+                     version,
+                     content,
+                     created_at,
+                     updated_at,
+                 }| {
+                    let mut changeset = Changeset::new(version as usize, content);
+                    changeset.updated_at = Some(updated_at);
+                    changeset.created_at = Some(created_at);
+
+                    changeset
+                },
+            )
+            .collect();
+        changesets.sort(); // by version, ascending
+
+        let mut snippet = Snippet::new(snippet_row.title, snippet_row.syntax, changesets, tags);
+        snippet.id = snippet_row.slug;
+        snippet.created_at = Some(snippet_row.created_at);
+        snippet.updated_at = Some(snippet_row.updated_at);
+
+        snippet
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from() {
+        let dt1 = chrono::DateTime::parse_from_rfc3339("2020-08-09T10:39:57+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let dt2 = chrono::DateTime::parse_from_rfc3339("2020-08-10T10:39:57+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let snippet_row = SnippetRow {
+            id: 42,
+            slug: "spam".to_string(),
+            title: Some("Hello".to_string()),
+            syntax: Some("python".to_string()),
+            created_at: dt1,
+            updated_at: dt2,
+        };
+        let changeset_rows = vec![
+            ChangesetRow {
+                id: 2,
+                snippet_id: 42,
+                version: 2,
+                content: "print('Hello, World!')".to_string(),
+                created_at: dt2,
+                updated_at: dt2,
+            },
+            ChangesetRow {
+                id: 1,
+                snippet_id: 42,
+                version: 1,
+                content: "print('Hello!')".to_string(),
+                created_at: dt1,
+                updated_at: dt1,
+            },
+        ];
+        let tag_rows = vec![
+            TagRow {
+                id: 1,
+                snippet_id: 42,
+                value: "spam".to_string(),
+            },
+            TagRow {
+                id: 2,
+                snippet_id: 42,
+                value: "eggs".to_string(),
+            },
+        ];
+
+        let actual = Snippet::from((snippet_row, changeset_rows, tag_rows));
+        let expected = Snippet {
+            id: "spam".to_string(),
+            title: Some("Hello".to_string()),
+            syntax: Some("python".to_string()),
+            changesets: vec![
+                Changeset {
+                    version: 1,
+                    content: "print('Hello!')".to_string(),
+                    created_at: Some(dt1),
+                    updated_at: Some(dt1),
+                },
+                Changeset {
+                    version: 2,
+                    content: "print('Hello, World!')".to_string(),
+                    created_at: Some(dt2),
+                    updated_at: Some(dt2),
+                },
+            ],
+            tags: vec!["spam".to_string(), "eggs".to_string()],
+            created_at: Some(dt1),
+            updated_at: Some(dt2),
+        };
+
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
Trait `Storage` defines a basic CRUD interface for storing/loading snippets from a persistent database. The only implementation planned as of now is `SqlStorage,` which only supports PostgreSQL at the moment, while in the future it should be relatively easy to extend it to support SQLite and MySQL if desired (we would need to stop using `INSERT ... ON CONFLICT DO ...` , though).