### PR TITLE
Extend Storage to support listing snippets

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,7 +3,7 @@ mod models;
 mod sql;
 
 pub use errors::StorageError;
-pub use models::{Changeset, Snippet};
+pub use models::{Changeset, ListSnippetsQuery, Snippet};
 pub use sql::SqlStorage;
 
 /// CRUD interface for storing/loading snippets from a persistent storage.
@@ -13,6 +13,9 @@ pub use sql::SqlStorage;
 pub trait Storage: Send + Sync {
     /// Save the state of the given snippet to the persistent storage.
     fn create(&self, snippet: &Snippet) -> Result<Snippet, StorageError>;
+
+    /// Returns a list of snippets that satisfy the given criteria.
+    fn list(&self, criteria: ListSnippetsQuery) -> Result<Vec<Snippet>, StorageError>;
 
     /// Returns the snippet uniquely identified by a given id (a slug or a
     /// legacy numeric id)

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -3,6 +3,7 @@ use std::iter;
 use chrono::{DateTime, Utc};
 use rand::Rng;
 
+const DEFAULT_LIMIT_SIZE: usize = 20;
 const DEFAULT_SLUG_LENGTH: usize = 8;
 
 /// A code snippet
@@ -53,6 +54,38 @@ impl Snippet {
         iter::repeat_with(|| rng.sample(rand::distributions::Alphanumeric))
             .take(length)
             .collect()
+    }
+}
+
+#[derive(Debug)]
+pub struct ListSnippetsQuery {
+    /// If set, only the snippets with the specified title will be returned.
+    pub title: Option<String>,
+    /// If set, only the snippets with the specified syntax will be returned.
+    pub syntax: Option<String>,
+    /// If set, only the snippets that have *one of* the specified tags attached
+    /// will be returned.
+    pub tags: Option<Vec<String>>,
+    /// If set, up to this number of snippets will be returned.
+    pub limit: Option<usize>,
+    /// If set, this number of snippets will be skipped (snippets are sorted in
+    /// the reverse chronological order) before the limit is applied.
+    pub offset: Option<usize>,
+}
+
+impl Default for ListSnippetsQuery {
+    fn default() -> Self {
+        // default filters should match all snippets. The only constraint we want
+        // to enforce is the maximum number of snippets in the response. Here it
+        // is set to a fairly small value; API users are expected to use pagination
+        // to retrieve more snippets if needed.
+        ListSnippetsQuery {
+            title: None,
+            syntax: None,
+            tags: None,
+            limit: Some(DEFAULT_LIMIT_SIZE),
+            offset: None,
+        }
     }
 }
 

--- a/src/storage/sql/models.rs
+++ b/src/storage/sql/models.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::convert::From;
 
 use chrono::{DateTime, Utc};
@@ -64,6 +65,44 @@ impl From<(SnippetRow, Vec<ChangesetRow>, Vec<TagRow>)> for Snippet {
 
         snippet
     }
+}
+
+pub fn combine_rows(
+    snippets: Vec<SnippetRow>,
+    changesets: Vec<ChangesetRow>,
+    tags: Vec<TagRow>,
+) -> Vec<Snippet> {
+    let mut changesets_by_snippet_id = BTreeMap::new();
+    for changeset in changesets {
+        changesets_by_snippet_id
+            .entry(changeset.snippet_id)
+            .or_insert_with(Vec::new)
+            .push(changeset);
+    }
+
+    let mut tags_by_snippet_id = BTreeMap::new();
+    for tag in tags {
+        tags_by_snippet_id
+            .entry(tag.snippet_id)
+            .or_insert_with(Vec::new)
+            .push(tag);
+    }
+
+    snippets
+        .into_iter()
+        .map(|snippet| {
+            let snippet_id = snippet.id;
+            Snippet::from((
+                snippet,
+                changesets_by_snippet_id
+                    .remove(&snippet_id)
+                    .unwrap_or_else(Vec::new),
+                tags_by_snippet_id
+                    .remove(&snippet_id)
+                    .unwrap_or_else(Vec::new),
+            ))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -142,6 +181,149 @@ mod tests {
             updated_at: Some(dt2),
         };
 
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_combine_rows() {
+        let dt1 = chrono::DateTime::parse_from_rfc3339("2020-08-09T10:39:57+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let dt2 = chrono::DateTime::parse_from_rfc3339("2020-08-10T10:39:57+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let snippet_rows = vec![
+            SnippetRow {
+                id: 42,
+                slug: "spam".to_string(),
+                title: Some("Hello".to_string()),
+                syntax: Some("python".to_string()),
+                created_at: dt1,
+                updated_at: dt2,
+            },
+            SnippetRow {
+                id: 43,
+                slug: "eggs".to_string(),
+                title: Some("Foo".to_string()),
+                syntax: Some("rust".to_string()),
+                created_at: dt1,
+                updated_at: dt2,
+            },
+            SnippetRow {
+                id: 44,
+                slug: "bar".to_string(),
+                title: Some("Bar".to_string()),
+                syntax: Some("cpp".to_string()),
+                created_at: dt1,
+                updated_at: dt2,
+            },
+        ];
+        let changeset_rows = vec![
+            ChangesetRow {
+                id: 4,
+                snippet_id: 44,
+                version: 1,
+                content: "std::cout << 42;".to_string(),
+                created_at: dt1,
+                updated_at: dt1,
+            },
+            ChangesetRow {
+                id: 2,
+                snippet_id: 42,
+                version: 2,
+                content: "print('Hello, World!')".to_string(),
+                created_at: dt2,
+                updated_at: dt2,
+            },
+            ChangesetRow {
+                id: 1,
+                snippet_id: 42,
+                version: 1,
+                content: "print('Hello!')".to_string(),
+                created_at: dt1,
+                updated_at: dt1,
+            },
+            ChangesetRow {
+                id: 3,
+                snippet_id: 43,
+                version: 1,
+                content: "println!(42);".to_string(),
+                created_at: dt1,
+                updated_at: dt1,
+            },
+        ];
+        let tag_rows = vec![
+            TagRow {
+                id: 1,
+                snippet_id: 42,
+                value: "spam".to_string(),
+            },
+            TagRow {
+                id: 2,
+                snippet_id: 42,
+                value: "eggs".to_string(),
+            },
+            TagRow {
+                id: 3,
+                snippet_id: 44,
+                value: "bar".to_string(),
+            },
+        ];
+
+        let actual = combine_rows(snippet_rows, changeset_rows, tag_rows);
+        let expected = vec![
+            Snippet {
+                id: "spam".to_string(),
+                title: Some("Hello".to_string()),
+                syntax: Some("python".to_string()),
+                changesets: vec![
+                    Changeset {
+                        version: 1,
+                        content: "print('Hello!')".to_string(),
+                        created_at: Some(dt1),
+                        updated_at: Some(dt1),
+                    },
+                    Changeset {
+                        version: 2,
+                        content: "print('Hello, World!')".to_string(),
+                        created_at: Some(dt2),
+                        updated_at: Some(dt2),
+                    },
+                ],
+                tags: vec!["spam".to_string(), "eggs".to_string()],
+                created_at: Some(dt1),
+                updated_at: Some(dt2),
+            },
+            Snippet {
+                id: "eggs".to_string(),
+                title: Some("Foo".to_string()),
+                syntax: Some("rust".to_string()),
+                changesets: vec![Changeset {
+                    version: 1,
+                    content: "println!(42);".to_string(),
+                    created_at: Some(dt1),
+                    updated_at: Some(dt1),
+                }],
+                tags: vec![],
+                created_at: Some(dt1),
+                updated_at: Some(dt2),
+            },
+            Snippet {
+                id: "bar".to_string(),
+                title: Some("Bar".to_string()),
+                syntax: Some("cpp".to_string()),
+                changesets: vec![Changeset {
+                    version: 1,
+                    content: "std::cout << 42;".to_string(),
+                    created_at: Some(dt1),
+                    updated_at: Some(dt1),
+                }],
+                tags: vec!["bar".to_string()],
+                created_at: Some(dt1),
+                updated_at: Some(dt2),
+            },
+        ];
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
In addition to the basic CRUD interface we want Storage to allow for listing snippets that satisfy the given criteria. Note, that this initial implementation does not support marker-based pagination yet.