### PR TITLE
Add 'setup-postgres' action

### DIFF
--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -1,0 +1,62 @@
+name: Setup PostgreSQL
+description: |
+  Setup a PostgreSQL for Linux, macOS and Windows machines. Runs natively, no
+  Docker containers are involved.
+inputs:
+  username:
+    description: A username of the user to setup.
+    default: postgres
+  password:
+    description: A password of the user to setup.
+    default: postgres
+  database:
+    description: A database name to setup and grant permissions to created user.
+    default: postgres
+runs:
+  using: composite
+  steps:
+    - name: Prerequisites
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          echo "$(pg_config --bindir)" >> $GITHUB_PATH
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          echo "$PGBIN" >> $GITHUB_PATH
+          echo "PQ_LIB_DIR=$PGROOT\lib" >> $GITHUB_ENV
+        fi
+      shell: bash
+
+
+    - name: Setup and start PostgreSQL
+      run: |
+        export PGDATA="$RUNNER_TEMP/pgdata"
+        pg_ctl init
+
+        # Forbid creating unix sockets since they are created by default in the
+        # directory we don't have permissions to.
+        echo "unix_socket_directories = ''" >> "$PGDATA/postgresql.conf"
+        pg_ctl start
+
+        # Both PGHOST and PGUSER are used by PostgreSQL tooling such as 'psql'
+        # or 'createuser'. Since PostgreSQL data has been resetup, we cannot
+        # rely on defaults anymore.
+        #
+        # PGHOST is required for Linux and macOS since they default to unix
+        # sockets, and we have turned them off.
+        #
+        # PGUSER is required for Windows since default the tooling's default
+        # user is 'postgres', while 'pg_ctl init' creates one with the name of
+        # the current user.
+        echo "PGHOST=localhost" >> $GITHUB_ENV
+        echo "PGUSER=${USER:-$USERNAME}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Setup PostgreSQL user and database
+      run: |
+        createuser ${{ inputs.username }}
+
+        if [ "${{ inputs.database}}" != "postgres" ]; then
+          createdb -O ${{ inputs.username }} ${{ inputs.database }}
+        fi
+
+        psql -c "ALTER USER ${{ inputs.username }} PASSWORD '${{ inputs.password }}';" ${{ inputs.database }}
+      shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
@@ -65,37 +69,12 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           override: true
 
-      - name: Start PostgreSQL and create a database  (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres createuser -s devel
-          sudo -u postgres createdb -O devel devel
-          sudo -u postgres psql -c "ALTER USER devel PASSWORD 'devel';" devel
-          echo "ROCKET_DATABASE_URL=postgres://devel:devel@localhost/devel" >> $GITHUB_ENV
+      - name: Start PostgreSQL
+        uses: ./.github/actions/setup-postgres
 
-      - name: Start PostgreSQL and create a database (MacOS)
-        if: runner.os == 'macOS'
+      - name: Set ROCKET_DATABASE_URL
         run: |
-          /usr/local/opt/postgres/bin/pg_ctl -D /usr/local/var/postgres start
-          /usr/local/opt/postgres/bin/createuser -s devel
-          /usr/local/opt/postgres/bin/createdb -O devel devel
-          /usr/local/opt/postgres/bin/psql -c "ALTER USER devel PASSWORD 'devel';" devel
-          echo "ROCKET_DATABASE_URL=postgres://devel:devel@localhost/devel" >> $GITHUB_ENV
-
-      - name: Start PostgreSQL and create a database (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          echo '$PGROOT\bin' >> $GITHUB_PATH
-          echo '$PGROOT\lib' >> $GITHUB_PATH
-          echo "PQ_LIB_DIR=$PGROOT\lib" >> $GITHUB_ENV
-          sc config postgresql-x64-13 start=demand
-          net start postgresql-x64-13
-          "$PGROOT\bin\createuser" -s devel
-          "$PGROOT\bin\createdb" -O devel devel
-          "$PGROOT\bin\psql" -c "ALTER USER devel PASSWORD 'devel';" devel
-          echo "ROCKET_DATABASE_URL=postgres://devel:devel@localhost/devel" >> $GITHUB_ENV
+          echo "ROCKET_DATABASE_URL=postgres://postgres:postgres@localhost/postgres" >> $GITHUB_ENV
 
       - name: Install Alembic and psycopg2
         run: |
@@ -137,13 +116,11 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Start PostgreSQL and create a database  (Linux)
-        run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres createuser -s devel
-          sudo -u postgres createdb -O devel devel
-          sudo -u postgres psql -c "ALTER USER devel PASSWORD 'devel';" devel
-          echo "ROCKET_DATABASE_URL=postgres://devel:devel@localhost/devel" >> $GITHUB_ENV
+      - name: Start PostgreSQL
+        uses: ./.github/actions/setup-postgres
+
+      - run: |
+          echo "ROCKET_DATABASE_URL=postgres://postgres:postgres@localhost/postgres" >> $GITHUB_ENV
 
       - run: cargo build
       - run: python -m venv testvenv


### PR DESCRIPTION
In order to improve workflows' readability, let's move the steps that
setup postgresql server into standalone action. This way it will be
easier reuse this code between the jobs, and the jobs will be much
simpler.