### PR TITLE
Make Snippet and Changeset serializable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,20 @@ name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+dependencies = [
+ "proc-macro2 1.0.19",
+ "quote 1.0.7",
+ "syn 1.0.35",
+]
 
 [[package]]
 name = "serde_json"
@@ -1212,6 +1226,8 @@ dependencies = [
  "rand",
  "rocket",
  "rocket_contrib",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ diesel = { version = "1.4.5", features = ["chrono", "postgres", "r2d2"] }
 rand = "0.7.3"
 rocket = "0.4.5"
 rocket_contrib = {version = "0.4.5", features = ["json"]}
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,10 +1,12 @@
 mod errors;
 mod models;
 mod sql;
+mod util;
 
 pub use errors::StorageError;
 pub use models::{Changeset, ListSnippetsQuery, Snippet};
 pub use sql::SqlStorage;
+pub use util::DateTime;
 
 /// CRUD interface for storing/loading snippets from a persistent storage.
 ///

--- a/src/storage/sql/models.rs
+++ b/src/storage/sql/models.rs
@@ -49,8 +49,8 @@ impl From<(SnippetRow, Vec<ChangesetRow>, Vec<TagRow>)> for Snippet {
                      updated_at,
                  }| {
                     let mut changeset = Changeset::new(version as usize, content);
-                    changeset.updated_at = Some(updated_at);
-                    changeset.created_at = Some(created_at);
+                    changeset.updated_at = Some(updated_at.into());
+                    changeset.created_at = Some(created_at.into());
 
                     changeset
                 },
@@ -60,8 +60,8 @@ impl From<(SnippetRow, Vec<ChangesetRow>, Vec<TagRow>)> for Snippet {
 
         let mut snippet = Snippet::new(snippet_row.title, snippet_row.syntax, changesets, tags);
         snippet.id = snippet_row.slug;
-        snippet.created_at = Some(snippet_row.created_at);
-        snippet.updated_at = Some(snippet_row.updated_at);
+        snippet.created_at = Some(snippet_row.created_at.into());
+        snippet.updated_at = Some(snippet_row.updated_at.into());
 
         snippet
     }
@@ -166,19 +166,19 @@ mod tests {
                 Changeset {
                     version: 1,
                     content: "print('Hello!')".to_string(),
-                    created_at: Some(dt1),
-                    updated_at: Some(dt1),
+                    created_at: Some(dt1.into()),
+                    updated_at: Some(dt1.into()),
                 },
                 Changeset {
                     version: 2,
                     content: "print('Hello, World!')".to_string(),
-                    created_at: Some(dt2),
-                    updated_at: Some(dt2),
+                    created_at: Some(dt2.into()),
+                    updated_at: Some(dt2.into()),
                 },
             ],
             tags: vec!["spam".to_string(), "eggs".to_string()],
-            created_at: Some(dt1),
-            updated_at: Some(dt2),
+            created_at: Some(dt1.into()),
+            updated_at: Some(dt2.into()),
         };
 
         assert_eq!(actual, expected);
@@ -281,19 +281,19 @@ mod tests {
                     Changeset {
                         version: 1,
                         content: "print('Hello!')".to_string(),
-                        created_at: Some(dt1),
-                        updated_at: Some(dt1),
+                        created_at: Some(dt1.into()),
+                        updated_at: Some(dt1.into()),
                     },
                     Changeset {
                         version: 2,
                         content: "print('Hello, World!')".to_string(),
-                        created_at: Some(dt2),
-                        updated_at: Some(dt2),
+                        created_at: Some(dt2.into()),
+                        updated_at: Some(dt2.into()),
                     },
                 ],
                 tags: vec!["spam".to_string(), "eggs".to_string()],
-                created_at: Some(dt1),
-                updated_at: Some(dt2),
+                created_at: Some(dt1.into()),
+                updated_at: Some(dt2.into()),
             },
             Snippet {
                 id: "eggs".to_string(),
@@ -302,12 +302,12 @@ mod tests {
                 changesets: vec![Changeset {
                     version: 1,
                     content: "println!(42);".to_string(),
-                    created_at: Some(dt1),
-                    updated_at: Some(dt1),
+                    created_at: Some(dt1.into()),
+                    updated_at: Some(dt1.into()),
                 }],
                 tags: vec![],
-                created_at: Some(dt1),
-                updated_at: Some(dt2),
+                created_at: Some(dt1.into()),
+                updated_at: Some(dt2.into()),
             },
             Snippet {
                 id: "bar".to_string(),
@@ -316,12 +316,12 @@ mod tests {
                 changesets: vec![Changeset {
                     version: 1,
                     content: "std::cout << 42;".to_string(),
-                    created_at: Some(dt1),
-                    updated_at: Some(dt1),
+                    created_at: Some(dt1.into()),
+                    updated_at: Some(dt1.into()),
                 }],
                 tags: vec!["bar".to_string()],
-                created_at: Some(dt1),
-                updated_at: Some(dt2),
+                created_at: Some(dt1.into()),
+                updated_at: Some(dt2.into()),
             },
         ];
         assert_eq!(actual, expected);

--- a/src/storage/util.rs
+++ b/src/storage/util.rs
@@ -1,0 +1,64 @@
+use serde::{Serialize, Serializer};
+
+type ChronoUtc = chrono::DateTime<chrono::Utc>;
+
+/// A wrapper around DateTime<Utc> from chrono that allows us
+/// to implement Serialize (otherwise, Rust forbids implementing
+/// a foreign trait for a foreign type from a different crate).
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DateTime(ChronoUtc);
+
+impl From<ChronoUtc> for DateTime {
+    fn from(value: ChronoUtc) -> Self {
+        Self(value)
+    }
+}
+impl From<DateTime> for ChronoUtc {
+    fn from(value: DateTime) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for DateTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_rfc3339())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_datetime_from() {
+        let reference = chrono::DateTime::parse_from_rfc3339("2020-08-09T10:39:57+00:00")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        // from() conversions work in both directions: chrono::DateTime --> DateTime
+        let dt = DateTime::from(reference);
+        assert_eq!(dt.0, reference);
+
+        // and DateTime --> chrono::DateTime
+        let chrono_dt = chrono::DateTime::from(dt);
+        assert_eq!(chrono_dt, reference);
+    }
+
+    #[test]
+    fn test_datetime_serialize() {
+        let reference = chrono::DateTime::parse_from_rfc3339("2020-08-09T10:39:57+00:00")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        let dt = DateTime::from(reference);
+
+        // DateTime is serialized to its string representation (JSON strings are
+        // enclosed in double quotes)
+        let expected = "\"2020-08-09T10:39:57+00:00\"";
+        let actual = serde_json::to_string(&dt).expect("failed to serilize DateTime");
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
In order to return Snippets in API responses, we need to make them serializable first. Rocket can handle serialization to JSON, but it requires the types to implement `serde::Serializable`.

In theory, we could just auto-derive that trait for our structs, but in practice it is more complicated than that, as `created_at` and `updated_at` are of type `DateTime<Utc>`, and the latter does not implement `serde::Serializable`.

Rust has this fair, but sometimes annoying requirement, that you can't implement foreign traits for foreign types. So the way to work around that is to create a wrapper struct around `DateTime<Utc>` from the chrono crate. This has no runtime/memory overhead, but it is a little verbose (because we need to handle type conversions).