### PR TITLE
Make Gabbit tests run DB migrations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Set ROCKET_DATABASE_URL
         run: |
-          echo "ROCKET_DATABASE_URL=postgres://postgres:postgres@localhost/postgres" >> $GITHUB_ENV
+          echo "ROCKET_DATABASE_URL=postgresql://postgres:postgres@localhost/postgres" >> $GITHUB_ENV
 
       - name: Install Alembic and psycopg2
         run: |
@@ -122,7 +122,7 @@ jobs:
         uses: ./.github/actions/setup-postgres
 
       - run: |
-          echo "ROCKET_DATABASE_URL=postgres://postgres:postgres@localhost/postgres" >> $GITHUB_ENV
+          echo "ROCKET_DATABASE_URL=postgresql://postgres:postgres@localhost/postgres" >> $GITHUB_ENV
 
       - run: cargo build
       - run: python -m venv testvenv

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,4 @@
+alembic >= 1.5.2
 gabbi >= 2.1.0
+psycopg2-binary >= 2.8.6
 pytest >= 6.2.1

--- a/tests/test_gabbits.py
+++ b/tests/test_gabbits.py
@@ -1,3 +1,4 @@
+import alembic.config
 import json
 import os
 import random
@@ -47,6 +48,9 @@ class XSnippetApi(gabbi.fixture.GabbiFixture):
 
         environ = os.environ.copy()
         environ.update(self.environ)
+
+        # run database migrations (requires ROCKET_DATABASE_URL to be set)
+        alembic.config.main(['upgrade', 'head'])
 
         # capture stdout/stderr of xsnippet-api process to a temporary file.
         # Alternatively, we could either connect the child process to our


### PR DESCRIPTION
As briefly discussed in the comments to #112, we want to make the Gabbit tests more self-sufficient: given a database URL, they should be able to start an instance of xsnippet-api, including running the DB migrations by the means of alembic.

While we are at this, fix the warning emitted by SQLAlchemy: the name of the DB API driver has been changed from `postgres` to `postgresql`. Diesel is happy with both, so no change there.