### PR TITLE
Implement the /snippets/<id> route

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -43,6 +43,7 @@ pub fn create_app() -> Result<rocket::Rocket, Box<dyn Error>> {
 
     let routes = routes![
         routes::snippets::create_snippet,
+        routes::snippets::get_snippet,
         routes::syntaxes::get_syntaxes,
     ];
     Ok(app

--- a/src/routes/snippets.rs
+++ b/src/routes/snippets.rs
@@ -81,3 +81,8 @@ pub fn create_snippet(
 
     Ok(Created(location, Some(response)))
 }
+
+#[get("/snippets/<id>")]
+pub fn get_snippet(storage: State<Box<dyn Storage>>, id: String) -> Result<JsonValue, ApiError> {
+    Ok(json!(storage.get(&id)?))
+}

--- a/tests/gabbits/get-snippet-errors.yaml
+++ b/tests/gabbits/get-snippet-errors.yaml
@@ -1,0 +1,31 @@
+fixtures:
+  - XSnippetApi
+
+tests:
+  - name: create a new snippet
+    POST: /v1/snippets
+    request_headers:
+      content-type: application/json
+    data:
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+    status: 201
+
+  - name: retrieve snippet (unsupported accept)
+    GET: $LOCATION
+    request_headers:
+      accept: text/html
+    response_headers:
+      content-type: application/json
+    status: 406
+    skip: content negotiation is not implemented yet
+
+  - name: retrieve snippet (not found)
+    GET: /v1/snippets/foobar
+    response_headers:
+      content-type: application/json
+    response_json_paths:
+      $.message: Snippet with id `foobar` is not found
+      $.`len`: 1
+    status: 404

--- a/tests/gabbits/get-snippet.yaml
+++ b/tests/gabbits/get-snippet.yaml
@@ -1,0 +1,54 @@
+common:
+  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}$/
+  - &slug_regex /^[a-zA-Z0-9]+$/
+
+fixtures:
+  - XSnippetApi
+
+tests:
+  - name: create a new snippet
+    POST: /v1/snippets
+    request_headers:
+      content-type: application/json
+    data:
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+      tags:
+        - spam
+        - eggs
+    status: 201
+
+  - name: retrieve previously created snippet via Location header
+    GET: $LOCATION
+    response_headers:
+      content-type: application/json
+    response_json_paths:
+      $.id: *slug_regex
+      $.title: Hello, World!
+      $.syntax: python
+      $.content: print('Hello, World!')
+      $.created_at: *datetime_regex
+      $.updated_at: *datetime_regex
+      $.tags.`sorted`:
+        - eggs
+        - spam
+      $.`len`: 7
+    status: 200
+
+  - name: retrieve previously created snippet by ID
+    GET: /v1/snippets/$HISTORY['create a new snippet'].$RESPONSE['id']
+    response_headers:
+      content-type: application/json
+    response_json_paths:
+      $.id: *slug_regex
+      $.title: Hello, World!
+      $.syntax: python
+      $.content: print('Hello, World!')
+      $.created_at: *datetime_regex
+      $.updated_at: *datetime_regex
+      $.tags.`sorted`:
+        - eggs
+        - spam
+      $.`len`: 7
+    status: 200


### PR DESCRIPTION
This patch imeplements a route that retrieves the snippet by ID. With
storage layer in place, it merely a few lines of Rocket shim and dozens
lines of Gabbi tests.