### PR TITLE
Use chrono with "serde" feature enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,13 +144,16 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = [
 publish = false
 
 [dependencies]
-chrono = "0.4.13"
+chrono = { version = "0.4.19", features = ["serde"] }
 diesel = { version = "1.4.5", features = ["chrono", "postgres", "r2d2"] }
 rand = "0.7.3"
 rocket = "0.4.5"

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -76,8 +76,8 @@ impl Serialize for Snippet {
         s.serialize_field("syntax", &self.syntax)?;
         s.serialize_field("content", &self.changesets.last().map(|v| &v.content))?;
         s.serialize_field("tags", &self.tags)?;
-        s.serialize_field("created_at", &self.created_at.map(|v| v.to_rfc3339()))?;
-        s.serialize_field("updated_at", &self.updated_at.map(|v| v.to_rfc3339()))?;
+        s.serialize_field("created_at", &self.created_at)?;
+        s.serialize_field("updated_at", &self.updated_at)?;
         s.end()
     }
 }
@@ -364,7 +364,7 @@ mod tests {
             \"syntax\":\"python\",\
             \"content\":\"print(42)\",\
             \"tags\":[\"foo\",\"bar\"],\
-            \"created_at\":\"2020-08-09T10:39:57+00:00\",\
+            \"created_at\":\"2020-08-09T10:39:57Z\",\
             \"updated_at\":null\
         }";
         let actual = serde_json::to_string(&reference).expect("failed to serialize snippet");

--- a/tests/gabbits/create-snippet.yaml
+++ b/tests/gabbits/create-snippet.yaml
@@ -1,5 +1,5 @@
 common:
-  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}$/
+  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(\+\d{2}:\d{2})|Z$/
   - &slug_regex /^[a-zA-Z0-9]+$/
   - &location_regex /^/v1/snippets/[a-zA-Z0-9]+$/
 


### PR DESCRIPTION
This allows us not to call .to_rfc3339() explicitly and rely on chrono choosing the correct serialization format.

One difference is that the timestamps in UTC now use the Z suffix instead of encoding the HOURS:MINUTES offset (+00:00). Both are valid representations according to the standard. Account for that in the regexp that we use in tests.