### PR TITLE
Add a basic Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,3 +128,38 @@ jobs:
       - run: python -m venv testvenv
       - run: ./testvenv/bin/python -m pip install -r tests/requirements.txt
       - run: ./testvenv/bin/python -m pytest -vv tests/
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build a Docker image (deploy)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          target: deploy
+          push: false
+          tags: xsnippet-api:deploy
+
+      - name: Build a Docker image (debug)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          target: debug
+          push: false
+          tags: xsnippet-api:debug
+
+      - name: Build a Docker image (release)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          target: release
+          push: false
+          tags: xsnippet-api:latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ categories = [
 ]
 publish = false
 
+[profile.release]
+debug = true
+
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
 diesel = { version = "1.4.5", features = ["chrono", "postgres", "r2d2"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# build image (rustc and Cargo that can build xsnippet-api from source)
+FROM rustlang/rust:nightly AS builder
+WORKDIR /usr/src/xsnippet-api
+
+# first, copy Cargo.toml and prebuild all dependencies, so that we do not have to do
+# that every single time when the source code of the application is updated
+COPY Cargo.toml Cargo.toml
+RUN mkdir src/ && \
+    echo "fn main() {println!(\"if you see this, the build broke\")}" > src/main.rs && \
+    cargo build --release && \
+    cargo test && \
+    rm -f target/release/deps/xsnippet-api*
+
+# now copy the source code and build the application itself
+COPY . .
+RUN touch src/main.rs && cargo install --path . && mv /usr/local/cargo/bin/xsnippet-api /usr/local/bin/xsnippet-api
+RUN objcopy --only-keep-debug /usr/local/bin/xsnippet-api /usr/local/bin/xsnippet-api.dbg && \
+    objcopy --strip-debug /usr/local/bin/xsnippet-api && \
+    objcopy --add-gnu-debuglink=/usr/local/bin/xsnippet-api.dbg /usr/local/bin/xsnippet-api
+
+# deploy image (DB schema migrations and the Python libraries required for running them)
+FROM debian:buster-slim AS deploy
+RUN apt-get update && apt-get install -y python3-alembic python3-psycopg2 && rm -rf /var/lib/apt/lists/*
+COPY . /usr/src/xsnippet-api
+WORKDIR /usr/src/xsnippet-api
+
+# base image (xsnippet-api executable and its dynamic dependencies)
+FROM debian:buster-slim AS base
+RUN apt-get update && apt-get install -y libpq5 && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/bin/xsnippet-api /usr/local/bin/xsnippet-api
+ENV ROCKET_ADDRESS=localhost \
+    ROCKET_PORT=8000 \
+    RUST_BACKTRACE=1
+EXPOSE $ROCKET_PORT
+ENTRYPOINT ["xsnippet-api"]
+
+# debug image (same as base, but also packs the debugging symbols)
+FROM base AS debug
+COPY --from=builder /usr/local/bin/xsnippet-api.dbg /usr/local/bin/xsnippet-api.dbg
+
+# release image (just an alias for base, so that it's the target that we build by default)
+FROM base AS release


### PR DESCRIPTION
Rust binaries are linked statically, so we can just copy the executable
to the target image. The only requirement that we have is that the image
should provide glibc and libpq.

The Dockerfile has multiple stages:

* builder: a large image that comes with rustc and Cargo installed and
  is suitable for building Rust code. We use it to compile xsnippet-api
  and prepare two object files: the xsnippet-api executable, and its
  stripped debugging symbols

* deploy (~160 MiB): an auxiliary image that can run the DB schema migrations

* base (~80 MiB): a slim target image based on Debian that will be used for
  running xsnippet-api. Provides the dynamic depedendices (glibc and libpq)
  and sets the necessary Dockerfile instructions like EXPOSE or ENV

* debug (~120 MiB): same as base, but also copies the stripped debugging symbols
  from the builder

* release (~80 MiB): same as base. Basically, it's just an alias. The only
  reason it exists is so that we can share the Dockerfile instructions between
  debug and release, and have release be the default build target