### PR TITLE
Fix the tests on CI

### DIFF
--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -278,6 +278,7 @@ mod tests {
             assert_eq!(id.len(), length);
             assert!(
                 id.chars().all(|c| c.is_ascii_alphanumeric()),
+                "is_ascii_alphanumeric() returned false: {}",
                 id.to_string()
             );
         }

--- a/tests/gabbits/get-snippet.yaml
+++ b/tests/gabbits/get-snippet.yaml
@@ -1,5 +1,5 @@
 common:
-  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}$/
+  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(\+\d{2}:\d{2})|Z$/
   - &slug_regex /^[a-zA-Z0-9]+$/
 
 fixtures:


### PR DESCRIPTION
The latest nightly release of rustc complains that we are using `assert!()` wrong: the second argument should be a static string literal that specifies how to format the resulting error message.