### PR TITLE
Create a temporary database in the XSnippetApi fixture

### DIFF
--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -59,4 +59,5 @@ runs:
         fi
 
         psql -c "ALTER USER ${{ inputs.username }} PASSWORD '${{ inputs.password }}';" ${{ inputs.database }}
+        psql -c "ALTER ROLE ${{ inputs.username }} CREATEDB;" ${{ inputs.database }}
       shell: bash


### PR DESCRIPTION
Currently, our tests update the database state but never clean it up,which will become problematic in the future, e.g. when we implement listing of snippets.

One way to deal with this would be to delete all table rows between test runs, but that effectively wipes out the database that
ROCKET_DATABASE_URL points to, which can be destructive when used in the wrong environment, or just annoying when it drops the state of a local XSnippet API instance.

Alternatively, we can create a temporary database in start_fixture(), and use for a single Gabbi test (i.e. one YAML file with test cases).