### PR TITLE
Add basic logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,7 +261,7 @@ checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.63",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -318,7 +327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -501,6 +510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,9 +523,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
 name = "lock_api"
@@ -537,6 +552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -662,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,7 +740,7 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
- "version_check 0.9.2",
+ "version_check 0.9.3",
  "yansi",
 ]
 
@@ -725,6 +755,12 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "polyval"
@@ -890,6 +926,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+
+[[package]]
 name = "rocket"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,7 +967,7 @@ dependencies = [
  "state",
  "time",
  "toml",
- "version_check 0.9.2",
+ "version_check 0.9.3",
  "yansi",
 ]
 
@@ -921,7 +982,7 @@ dependencies = [
  "indexmap",
  "quote 0.6.13",
  "rocket_http",
- "version_check 0.9.2",
+ "version_check 0.9.3",
  "yansi",
 ]
 
@@ -1008,7 +1069,7 @@ checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
- "syn 1.0.63",
+ "syn 1.0.64",
 ]
 
 [[package]]
@@ -1033,6 +1094,15 @@ dependencies = [
  "cpuid-bool 0.1.2",
  "digest",
  "opaque-debug",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1072,13 +1142,22 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1114,6 +1193,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log 0.4.14",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1217,9 +1371,9 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"
@@ -1308,6 +1462,8 @@ dependencies = [
  "rocket_contrib",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,6 @@ rocket = "0.4.5"
 rocket_contrib = {version = "0.4.5", features = ["json"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tracing = "0.1.25"
+tracing-subscriber = "0.2.16"
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/src/application.rs
+++ b/src/application.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 use super::routes;
 use super::storage::{SqlStorage, Storage};
-use super::web::RequestIdHeader;
+use super::web::{RequestIdHeader, RequestSpan};
 
 #[derive(Debug)]
 pub struct Config {
@@ -51,5 +51,6 @@ pub fn create_app() -> Result<rocket::Rocket, Box<dyn Error>> {
         .manage(Config { syntaxes })
         .manage(storage)
         .attach(RequestIdHeader)
+        .attach(RequestSpan)
         .mount("/v1", routes))
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -74,14 +74,14 @@ impl<'r> Responder<'r> for ApiError {
     fn respond_to(self, request: &Request) -> response::Result<'r> {
         if let ApiError::InternalError(_) = self {
             // do not give away any details for internal server errors
-            // TODO: integrate with Rocket contextual logging when 0.5 is released
-            eprintln!("Internal server error: {}", self.reason());
+            error!("Internal server error: {}", self.reason());
             Response::build()
                 .status(http::Status::InternalServerError)
                 .ok()
         } else {
             // otherwise, present the error in the requested data format
             let http_status = self.status();
+            debug!("ApiError: {:?}", self);
             Response::build_from(Output(self).respond_to(request)?)
                 .status(http_status)
                 .ok()

--- a/src/storage/sql/mod.rs
+++ b/src/storage/sql/mod.rs
@@ -390,7 +390,7 @@ mod tests {
 
             test_function(Box::new(SqlStorage { pool }));
         } else {
-            eprintln!("ROCKET_DATABASE_URL is not set, skipping the test");
+            error!("ROCKET_DATABASE_URL is not set, skipping the test");
         }
     }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,5 +1,5 @@
 mod content;
 mod tracing;
 
-pub use content::{Input, NegotiatedContentType, Output};
-pub use tracing::{RequestId, RequestIdHeader};
+pub use crate::web::content::{Input, NegotiatedContentType, Output};
+pub use crate::web::tracing::{RequestId, RequestIdHeader, RequestSpan};

--- a/src/web/content.rs
+++ b/src/web/content.rs
@@ -102,7 +102,7 @@ impl<'a, T: Serialize> Responder<'a> for Output<T> {
                 } else {
                     // this shouldn't be possible as by this point content negotiation has already
                     // succeded
-                    eprintln!("Failed to serialize data to {}", content_type);
+                    error!("Failed to serialize data to {}", content_type);
                     Err(Status::InternalServerError)
                 }
             }

--- a/src/web/tracing.rs
+++ b/src/web/tracing.rs
@@ -1,6 +1,10 @@
+use std::cell::RefCell;
+
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::request::{self, FromRequest, Request};
-use rocket::{Outcome, Response};
+use rocket::{Data, Outcome, Response};
+use tracing::field::Empty;
+use tracing::span::EnteredSpan;
 
 /// Unique identifier assigned to a given API request.
 pub struct RequestId(pub String);
@@ -42,7 +46,71 @@ impl Fairing for RequestIdHeader {
         if let Some(request_id) = request.guard::<&RequestId>().succeeded() {
             response.set_raw_header("X-Request-Id", request_id.0.clone());
         } else {
-            eprintln!("Failed to generate a request id");
+            error!("Failed to generate a request id");
         }
+    }
+}
+
+/// Rocket fairing that creates and destroys a request `span`.
+///
+/// tracing framework uses a notion of `spans` to store contextual information
+/// alongside log events. For web applications a typical span would be a single
+/// HTTP request, which has a beginning and end time, unique request identifier,
+/// etc.
+///
+/// A natural point of integration with Rocket is a fairing, which allows us to
+/// execute some code before and after each HTTP request, which is exactly what
+/// we need for determining the boundaries of a request span.
+pub struct RequestSpan;
+
+// It is extremely annoying that we need to resort to storing the span guard in
+// a thread local instead of the Rocket Request local cache, but those two have
+// incompatible requirements:
+//
+//  * EnteredSpan is marked as !Send, so that it's not possible to move it
+//    between threads, as that would produce incorrect traces
+//
+//  * Request::local_cache() requires the type to be Send, even though the
+//    values are not actually transferred between threads
+//
+// Using a thread-local is fine, because both on_request()/on_response() and the
+// actual request handler are executed in the same thread.
+thread_local!(static REQUEST_SPAN: RefCell<Option<EnteredSpan>> = RefCell::new(None));
+
+impl Fairing for RequestSpan {
+    fn info(&self) -> Info {
+        Info {
+            name: "Request span",
+            kind: Kind::Request | Kind::Response,
+        }
+    }
+
+    fn on_request(&self, request: &mut Request, _: &Data) {
+        if let Some(RequestId(request_id)) = request.guard::<&RequestId>().succeeded() {
+            let span = info_span!(
+                "request",
+                id = request_id.as_str(),
+                method = request.method().as_str(),
+                uri = request.uri().to_string().as_str(),
+                status = Empty,
+            );
+
+            REQUEST_SPAN.with(|cell| cell.borrow_mut().replace(span.entered()));
+        }
+    }
+
+    fn on_response(&self, _: &Request, response: &mut Response) {
+        REQUEST_SPAN.with(|cell| {
+            if let Some(span) = cell.borrow_mut().take() {
+                let status = response.status();
+
+                span.record("status", &status.code);
+                if status.class().is_success() {
+                    info!("request succeeded");
+                } else {
+                    warn!("request failed");
+                }
+            }
+        });
     }
 }

--- a/tests/test_gabbits.py
+++ b/tests/test_gabbits.py
@@ -36,6 +36,8 @@ class XSnippetApi(gabbi.fixture.GabbiFixture):
         self.environ = {
             "ROCKET_ADDRESS": XSNIPPET_API_HOST,
             "ROCKET_PORT": str(XSNIPPET_API_PORT),
+            "ROCKET_LOG": "critical",
+            "ROCKET_TRACING": "debug",
         }
 
         if self._syntaxes:


### PR DESCRIPTION
`tracing` is a framework that allows to set up structured logging with contextual information. In addition to traditional _events_, it also has a notion of _spans_, which are logical blocks of actions that represent a unit of work performed by an application. For web applications, it's natural to treat a single request as a span. All events logged in a context of a span will have the same structured contextual information, e.g. request id, HTTP method, URI, status code, etc.

Our current setup is very basic, but tracing can do much more:

* spans can be nested. Libraries can create their own spans, which will attach to our request spans. E.g. it may be possible to trace all SQL requests executed by Diesel for a given API request

* multiple subscribers can be configured. Instead of logging this information as text to stdout, we can configure it to be logged as JSON (or the OpenTracing format) for further analysis

At the very least, this allows us to ditch the `eprintln!()` statements and get a better logging than what Rocket comes with out-of-the-box.

Logging level is controlled by setting the `ROCKET_TRACING` variable to one of the following lvels: `debug`, `info`, `error`, `trace`, `warn`. The output looks like this:

```
Mar 06 21:33:03.750  INFO request{id="241137c1-79f1-4d2d-a5a0-30bdeaa680ff" method="GET" uri="/v1/snippets/1ssZckPV" status=200}: xsnippet_api::web::tracing: request succeeded
Mar 06 21:33:06.545  INFO request{id="17feead9-56cf-4180-8506-d42f8b7b02ff" method="GET" uri="/v1/snippets/1ssZckPV" status=200}: xsnippet_api::web::tracing: request succeeded
Mar 06 21:33:17.249 DEBUG request{id="a3858f9a-3257-41a1-8624-9b1ad3cf32de" method="GET" uri="/v1/snippets/1ssZckPa"}: xsnippet_api::errors: ApiError: NotFound("Snippet with id `1ssZckPa` is not found")
Mar 06 21:33:17.249  WARN request{id="a3858f9a-3257-41a1-8624-9b1ad3cf32de" method="GET" uri="/v1/snippets/1ssZckPa" status=404}: xsnippet_api::web::tracing: request failed
Mar 06 21:33:30.214  INFO request{id="44abdec6-8046-44fb-a909-57d5f02b789d" method="POST" uri="/v1/snippets" status=201}: xsnippet_api::web::tracing: request succeeded
```