### PR TITLE
Fix the tests on CI

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-SQLAlchemy>=1.4.0
+SQLAlchemy >= 1.4.0
 alembic >= 1.5.2
 gabbi >= 2.1.0
 psycopg2-binary >= 2.8.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+SQLAlchemy>=1.4.0
 alembic >= 1.5.2
 gabbi >= 2.1.0
 psycopg2-binary >= 2.8.6

--- a/tests/test_gabbits.py
+++ b/tests/test_gabbits.py
@@ -60,8 +60,7 @@ class XSnippetApi(gabbi.fixture.GabbiFixture):
         )
 
         # create a temporary database with a random name
-        self.test_db_url = sqlalchemy.engine.url.make_url(str(self.management_db.url))
-        self.test_db_url.database = _random_name()
+        self.test_db_url = self.management_db.url.set(database=_random_name())
 
         with self.management_db.connect() as conn:
             conn.execute(


### PR DESCRIPTION
The new release of SQLAlchemy changed the API of class URL to make it immutable. In versions >= 1.4.0 that class has a new method - `set()` - which allows to update the components of the database url (like db name) by returning a new instance of URL. That actually looks nicer than what we had before (a copy + explicit attribute assignment).