### PR TITLE
Allow to "import" snippets via POST /v1/snippets/import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,9 +293,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.68",
 ]
 
 [[package]]
@@ -718,9 +718,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -769,15 +769,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
 dependencies = [
  "scopeguard",
 ]
@@ -1127,9 +1127,9 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.68",
 ]
 
 [[package]]
@@ -1187,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -1209,7 +1209,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
 ]
 
 [[package]]
@@ -1547,9 +1547,9 @@ version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.68",
 ]
 
 [[package]]
@@ -1661,11 +1661,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "unicode-xid 0.2.1",
 ]
@@ -1706,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1791,9 +1791,9 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.68",
 ]
 
 [[package]]
@@ -2012,9 +2012,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2024,24 +2024,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.14",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.68",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2051,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -2061,28 +2061,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
- "syn 1.0.65",
+ "syn 1.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/application.rs
+++ b/src/application.rs
@@ -70,6 +70,7 @@ pub fn create_app() -> Result<rocket::Rocket, Box<dyn Error>> {
         routes::snippets::create_snippet,
         routes::snippets::get_snippet,
         routes::syntaxes::get_syntaxes,
+        routes::snippets::import_snippet,
     ];
     Ok(app
         .manage(config)

--- a/src/routes/snippets.rs
+++ b/src/routes/snippets.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::convert::TryFrom;
 
 use rocket::http::uri::Origin;
 use rocket::response::status::Created;
@@ -7,8 +7,19 @@ use serde::Deserialize;
 
 use crate::application::Config;
 use crate::errors::ApiError;
-use crate::storage::{Changeset, Snippet, Storage};
+use crate::storage::{Changeset, DateTime, Snippet, Storage};
 use crate::web::{BearerAuth, Input, NegotiatedContentType, Output};
+
+fn create_snippet_impl(
+    storage: &dyn Storage,
+    snippet: &Snippet,
+    base_path: &str,
+) -> Result<Created<Output<Snippet>>, ApiError> {
+    let new_snippet = storage.create(snippet)?;
+
+    let location = vec![base_path.to_string(), new_snippet.id.to_string()].join("/");
+    Ok(Created(location, Some(Output(new_snippet))))
+}
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -24,18 +35,17 @@ pub struct NewSnippet {
     pub tags: Option<Vec<String>>,
 }
 
-impl NewSnippet {
-    pub fn validate(
-        self,
-        allowed_syntaxes: Option<&BTreeSet<String>>,
-    ) -> Result<Snippet, ApiError> {
-        if self.content.is_empty() {
+impl TryFrom<(&Config, NewSnippet)> for Snippet {
+    type Error = ApiError;
+
+    fn try_from((config, value): (&Config, NewSnippet)) -> Result<Self, Self::Error> {
+        if value.content.is_empty() {
             return Err(ApiError::BadRequest(String::from(
                 "`content` - empty values not allowed.",
             )));
         }
-        if let Some(syntax) = &self.syntax {
-            if let Some(allowed_syntaxes) = &allowed_syntaxes {
+        if let Some(syntax) = &value.syntax {
+            if let Some(allowed_syntaxes) = &config.syntaxes {
                 if !allowed_syntaxes.contains(syntax) {
                     return Err(ApiError::BadRequest(format!(
                         "`syntax` - unallowed value {}.",
@@ -46,10 +56,10 @@ impl NewSnippet {
         }
 
         Ok(Snippet::new(
-            self.title,
-            self.syntax,
-            vec![Changeset::new(0, self.content)],
-            self.tags.unwrap_or_default(),
+            value.title,
+            value.syntax,
+            vec![Changeset::new(0, value.content)],
+            value.tags.unwrap_or_default(),
         ))
     }
 }
@@ -63,10 +73,63 @@ pub fn create_snippet(
     _content_type: NegotiatedContentType,
     _user: BearerAuth,
 ) -> Result<Created<Output<Snippet>>, ApiError> {
-    let new_snippet = storage.create(&body?.0.validate(config.syntaxes.as_ref())?)?;
+    let snippet = Snippet::try_from((&*config, body?.0))?;
+    create_snippet_impl(&**storage, &snippet, origin.path())
+}
 
-    let location = vec![origin.path().to_string(), new_snippet.id.to_string()].join("/");
-    Ok(Created(location, Some(Output(new_snippet))))
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImportSnippet {
+    #[serde(flatten)]
+    pub new_snippet: NewSnippet,
+    /// Snippet identifier.
+    pub id: Option<String>,
+    /// Snippet creation date. May be omitted in the user request.
+    pub created_at: Option<DateTime>,
+    /// Snippet modification date. May be omitted in the user request.
+    pub updated_at: Option<DateTime>,
+}
+
+impl TryFrom<(&Config, ImportSnippet)> for Snippet {
+    type Error = ApiError;
+
+    fn try_from((config, value): (&Config, ImportSnippet)) -> Result<Self, Self::Error> {
+        let mut snippet = Snippet::try_from((config, value.new_snippet))?;
+        if let Some(id) = value.id {
+            snippet.id = id;
+        }
+        if value.created_at.is_some() {
+            snippet.created_at = value.created_at;
+        }
+        if value.updated_at.is_some() {
+            snippet.updated_at = value.updated_at;
+        }
+
+        Ok(snippet)
+    }
+}
+
+#[post("/snippets/import", data = "<body>")]
+pub fn import_snippet(
+    config: State<Config>,
+    storage: State<Box<dyn Storage>>,
+    origin: &Origin,
+    body: Result<Input<ImportSnippet>, ApiError>,
+    user: BearerAuth,
+    _content_type: NegotiatedContentType,
+) -> Result<Created<Output<Snippet>>, ApiError> {
+    if !user.0.can_import_snippets() {
+        return Err(ApiError::Forbidden(
+            "User is not allowed to import snippets".to_string(),
+        ));
+    }
+
+    let snippet = Snippet::try_from((&*config, body?.0))?;
+    let base_path = origin
+        .path()
+        .strip_suffix("/import")
+        .ok_or_else(|| ApiError::InternalError(format!("Invalid URI path: {}", origin.path())))?;
+    create_snippet_impl(&**storage, &snippet, base_path)
 }
 
 #[get("/snippets/<id>")]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,7 +3,7 @@ mod models;
 mod sql;
 
 pub use errors::StorageError;
-pub use models::{Changeset, Direction, ListSnippetsQuery, Snippet};
+pub use models::{Changeset, DateTime, Direction, ListSnippetsQuery, Snippet};
 pub use sql::SqlStorage;
 
 /// CRUD interface for storing/loading snippets from a persistent storage.

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -6,7 +6,7 @@ use serde::{ser::SerializeStruct, Serialize, Serializer};
 const DEFAULT_LIMIT_SIZE: usize = 20;
 const DEFAULT_SLUG_LENGTH: usize = 8;
 
-type DateTime = chrono::DateTime<chrono::Utc>;
+pub type DateTime = chrono::DateTime<chrono::Utc>;
 
 /// A code snippet
 #[derive(Debug, Default, Eq, PartialEq)]

--- a/src/web/auth/jwt.rs
+++ b/src/web/auth/jwt.rs
@@ -44,7 +44,7 @@ struct Claims {
     sub: String,
     /// Expiration time (seconds since Unix epoch).
     exp: usize,
-    /// Subject permissions (e.g. vec!["admin"])
+    /// Subject permissions (e.g. vec!["import"])
     permissions: Vec<Permission>,
 }
 
@@ -165,7 +165,6 @@ mod tests {
     const E: &str = "AQAB";
 
     const USER_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0.eyJzdWIiOiJ1c2VyIiwiYXVkIjoieHNuaXBwZXQtYXBpLXRlc3RzLWF1ZCIsImlzcyI6InhzbmlwcGV0LWFwaS10ZXN0cy1pc3MiLCJleHAiOjQ3NzAzNzU1NDQsInBlcm1pc3Npb25zIjpbXX0.doA6EeVLnp-MLNRTRUzg03rw9oUn5vDGv59zNysrcFfvkEiiYAtZMu-YW_N3YtE0qv2FTaGAXHryMqsEk8rsFv4uepDuOpzutnRoB4JDFTpvJkKYE4HZjsd8eHSAjFEuCvDjm7wnxoW0zDXH_zj1FITht-c3ua6KbgeevvDjpUgaR52Zou9HRyNa6ns5OKO7yJofA32IZaO7QH69iQiZ4o9WA8PfFNyuVqyQVkvZwpr68JLgl4qTTX4NIWV4wU4OWbIGN6-p4QSkS_Ljkau9sRKjnx4NYPbICMGWVThn_MKOfg26DjGZlI_0HFYDBLogJkTmmyT-5IIIWUqBgUKWYA";
-    const ADMIN_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0.eyJzdWIiOiJhZG1pbiIsImF1ZCI6InhzbmlwcGV0LWFwaS10ZXN0cy1hdWQiLCJpc3MiOiJ4c25pcHBldC1hcGktdGVzdHMtaXNzIiwiZXhwIjo0NzcwMzc1NTc3LCJwZXJtaXNzaW9ucyI6WyJhZG1pbiJdfQ.UzzepZLy3T-FDFYFmViKeKzWD1KFMQmHvlmr3tmc7XGCaqfB4TauXopnbqHJj7SbLe2oiP-8kePuu9_Sc_9AXNz2G1vbc9nrwAwqDv7RllG64iXMLPe2I9eooNrS-Vs70Jy40G5UjfFmqjAl2Qs8mpJnvkpj-EtLEAIertyW6VX7iv6ssMEAZzvC-6TwlJ70R6ntEq6jjQIIgNBVMdZphysX7DXUQvT1WJMlw7axCtIiBfTf5a9wasW3qX51k2Nn0oLnn9fBrayK0DJcRGKIcDy2clnXaz2vjLQlkKtHj-LFgTai6xkInEaEdnqsVJflJFzcLMvhmOWHmmcVgMirTQ";
     const EXPIRED_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0.eyJzdWIiOiJ1c2VyIiwiYXVkIjoieHNuaXBwZXQtYXBpLXRlc3RzLWF1ZCIsImlzcyI6InhzbmlwcGV0LWFwaS10ZXN0cy1pc3MiLCJleHAiOjE2MTY3NzIwMDYsInBlcm1pc3Npb25zIjpbXX0.AkC-xzeJ7OXi5fN-DXs43vKAjgsep5Cwx2e1c3hbv1jPpJVnwTD2M_A8Bphd8-mzMsuO017a_rZQIj30dzt3I5Z730Z4zHA_xPV4nl_6zsGzCYTwecT1qmOhTuiyP1PhdgveVQz-ImNDbAzD80PTUwW8Bv-r4R1wyrc5lRtj2ofF1h2_rqxWtRbQwvqmm_J4K8oklYWOrBPNFXJVOGVcji97LelBY6llWbfVUO2unNZBA7MbJLDMtuQHMIRSHn1PXSLA4MJbxOzT-kZC01OlpQWtGstxnITHc34ZDVe5M0v092PSe5J0o3_OBVCR405-rPK_EjLD8saPE3SK7X0Cfw";
     const INVALID_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0.eyJzdWIiOiJ1c2VyIiwiYXVkIjoieHNuaXBwZXQtYXBpLXRlc3RzLWF1ZCIsImlzcyI6InhzbmlwcGV0LWFwaS10ZXN0cy1pc3MiLCJleHAiOjQ3NzAzNzU1NDQsInBlcm1pc3Npb25zIjpbXX0.doA6EeVLnp-MLNRTRUzg03rw9oUn5vDGv59zNysrcFfvkEiiYAtZMu-YW_N3YtE0qv2FTaGAXHryMqsEk8rsFv4uepDuOpzutnRoB4JDFTpvJkKYE4HZjsd8eHSAjFEuCvDjm7wnxoW0zDXH_zj1FITht-c3ua6KbgeevvDjpUgaR52Zou9HRyNa6ns5OKO7yJofA32IZaO7QH69iQiZ4o9WA8PfFNyuVqyQVkvZwpr68JLgl4qTTX4NIWV4wU4OWbIGN6-p3QSkS_Ljkau9sRKjnx4NYPbICMGWVThn_MKOfg26DjGZlI_0HFYDBLogJkTmmyT-5IIIWUqBgUKWYA";
     const INVALID_HEADER_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJraWQiOiJ0ZXN0LWtleSJ9.eyJzdWIiOiJ1c2VyIiwiYXVkIjoieHNuaXBwZXQtYXBpLXRlc3RzLWF1ZCIsImlzcyI6InhzbmlwcGV0LWFwaS10ZXN0cy1pc3MiLCJleHAiOjQ3NzAzNzU1NDQsInBlcm1pc3Npb25zIjpbXX0.doA6EeVLnp-MLNRTRUzg03rw9oUn5vDGv59zNysrcFfvkEiiYAtZMu-YW_N3YtE0qv2FTaGAXHryMqsEk8rsFv4uepDuOpzutnRoB4JDFTpvJkKYE4HZjsd8eHSAjFEuCvDjm7wnxoW0zDXH_zj1FITht-c3ua6KbgeevvDjpUgaR52Zou9HRyNa6ns5OKO7yJofA32IZaO7QH69iQiZ4o9WA8PfFNyuVqyQVkvZwpr68JLgl4qTTX4NIWV4wU4OWbIGN6-p4QSkS_Ljkau9sRKjnx4NYPbICMGWVThn_MKOfg26DjGZlI_0HFYDBLogJkTmmyT-5IIIWUqBgUKWYA";
@@ -285,13 +284,6 @@ mod tests {
                 User::Authenticated {
                     name: String::from("user"),
                     permissions: Vec::new()
-                }
-            );
-            assert_eq!(
-                validator.validate(ADMIN_TOKEN).unwrap(),
-                User::Authenticated {
-                    name: String::from("admin"),
-                    permissions: vec![Permission::Admin],
                 }
             );
             match validator.validate(EXPIRED_TOKEN) {

--- a/tests/gabbits/auth.yaml
+++ b/tests/gabbits/auth.yaml
@@ -29,20 +29,6 @@ tests:
         - eggs
     status: 201
 
-  - name: create a new snippet as an authorized user (admin)
-    POST: /v1/snippets
-    request_headers:
-      authorization: Bearer $ENVIRON['TOKEN_ADMIN']
-      content-type: application/json
-    data:
-      title: Hello, World!
-      syntax: python
-      content: print('Hello, World!')
-      tags:
-        - spam
-        - eggs
-    status: 201
-
   - name: try to pass an empty Authorization header
     POST: /v1/snippets
     request_headers:

--- a/tests/gabbits/import-snippet.yaml
+++ b/tests/gabbits/import-snippet.yaml
@@ -1,0 +1,143 @@
+common:
+  - &created_at "2020-08-09T10:39:57Z"
+  - &updated_at "2020-12-03T13:08:28Z"
+  - &forbidden_msg "User is not allowed to import snippets"
+
+fixtures:
+  - XSnippetApiWithCustomAuthProvider
+
+tests:
+  - name: try to import a new snippet as a guest user (doesn't have permissions)
+    POST: /v1/snippets/import
+    request_headers:
+      content-type: application/json
+    data:
+      id: spam
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+      tags:
+        - spam
+        - eggs
+      created_at: *created_at
+      updated_at: *updated_at
+    status: 403
+    response_headers:
+      content-type: application/json
+    response_json_paths:
+      $:
+        message: *forbidden_msg
+
+  - name: try to import a new snippet as an authenticated user (doesn't have permissions)
+    POST: /v1/snippets/import
+    request_headers:
+      authorization: Bearer $ENVIRON['TOKEN_VALID']
+      content-type: application/json
+    data:
+      id: spam
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+      tags:
+        - spam
+        - eggs
+      created_at: *created_at
+      updated_at: *updated_at
+    status: 403
+    response_headers:
+      content-type: application/json
+    response_json_paths:
+      $:
+        message: *forbidden_msg
+
+  - name: import a new snippet as an authenticated user (importer)
+    POST: /v1/snippets/import
+    request_headers:
+      authorization: Bearer $ENVIRON['TOKEN_IMPORT']
+      content-type: application/json
+    data:
+      id: foo
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+      tags:
+        - spam
+        - eggs
+      created_at: *created_at
+      updated_at: *updated_at
+    status: 201
+    response_headers:
+      location: /v1/snippets/foo
+
+  - name: retrieve previously created snippet by ID
+    GET: /v1/snippets/foo
+    response_headers:
+      content-type: application/json
+    response_json_paths:
+      $.id: foo
+      $.title: Hello, World!
+      $.syntax: python
+      $.content: print('Hello, World!')
+      $.created_at: *created_at
+      $.updated_at: *updated_at
+      $.tags.`sorted`:
+        - eggs
+        - spam
+      $.`len`: 7
+    status: 200
+
+  - name: import a new snippet with ID that already exists
+    POST: /v1/snippets/import
+    request_headers:
+      authorization: Bearer $ENVIRON['TOKEN_IMPORT']
+      content-type: application/json
+    data:
+      id: foo
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+      tags:
+        - spam
+        - eggs
+      created_at: *created_at
+      updated_at: *updated_at
+    status: 409
+    response_headers:
+      content-type: application/json
+    response_json_paths:
+      $:
+        message: "Snippet with id `foo` already exists"
+
+  - name: import a new snippet with malformed creation date
+    POST: /v1/snippets/import
+    request_headers:
+      authorization: Bearer $ENVIRON['TOKEN_IMPORT']
+      content-type: application/json
+    data:
+      id: foo
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+      tags:
+        - spam
+        - eggs
+      created_at: "2020/08/09 10:39:57"
+      updated_at: *updated_at
+    status: 400
+
+  - name: import a new snippet with malformed modification date
+    POST: /v1/snippets/import
+    request_headers:
+      authorization: Bearer $ENVIRON['TOKEN_IMPORT']
+      content-type: application/json
+    data:
+      id: foo
+      title: Hello, World!
+      syntax: python
+      content: print('Hello, World!')
+      tags:
+        - spam
+        - eggs
+      created_at: *created_at
+      updated_at: "2020/08/09 10:39:57"
+    status: 400

--- a/tests/test_gabbits.py
+++ b/tests/test_gabbits.py
@@ -236,7 +236,7 @@ class XSnippetApiWithCustomAuthProvider(XSnippetApi):
 
         return {
             "TOKEN_VALID": generate("user"),
-            "TOKEN_ADMIN": generate("admin", permissions=("admin", )),
+            "TOKEN_IMPORT": generate("importer", permissions=("import", )),
             "TOKEN_EXPIRED": generate("user", expires_in=-3600),
             "TOKEN_UNKNOWN_KEY": generate("user", key_id="spam"),
             "TOKEN_UNSUPPORTED_ALGORITHM": generate("user", algorithm="PS256"),


### PR DESCRIPTION
Normally when new snippets are created, users are not allowed to specify the values of fields which are automatically generated,   e.g. `id`, `created_at`, and `updated_at`. This would, however, be very useful for "importing" the state of the previous incarnation of XSnippet API that is currently deployed to prod (so that we can leverage the API for this instead of INSERT'ing the values directly to the database).
    
Importing snippets should not be allowed to anyone, but only to users with the special `import` permission.
