### PR TITLE
Add a CI workflow to build xsnippet-api executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: release_params
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "::set-output name=prerelease::false"
+            echo "::set-output name=release_tag::${GITHUB_REF#refs/tags/}"
+            echo "::set-output name=title::${GITHUB_REF#refs/tags/}"
+          else
+            echo "::set-output name=prerelease::true"
+            echo "::set-output name=release_tag::latest"
+            echo "::set-output name=title::Development Build"
+          fi
+
+      - id: create_release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ steps.release_params.outputs.prerelease }}
+          automatic_release_tag: ${{ steps.release_params.outputs.release_tag }}
+          title: ${{ steps.release_params.outputs.title }}
+
+  build_assets:
+    needs: create_release
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        rust-version:
+          - nightly
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust-version }}
+          override: true
+
+      - uses: ./.github/actions/setup-postgres
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            echo "ASSET_NAME=xsnippet-api-${{ matrix.os }}.exe" >> $GITHUB_ENV
+            echo "ASSET_PATH=./target/release/xsnippet-api.exe" >> $GITHUB_ENV
+          else
+            echo "ASSET_NAME=xsnippet-api-${{ matrix.os }}" >> $GITHUB_ENV
+            echo "ASSET_PATH=./target/release/xsnippet-api" >> $GITHUB_ENV
+          fi
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: ${{ env.ASSET_NAME }}
+          asset_path: ${{ env.ASSET_PATH }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This will:

* create a new pre-release for every PR merged to master
* create a new release for every pushed version tag
    
For every release we build one binary per each supported platform (Linux, Mac OS, Windows). Note, that while Rust itself uses static linking for everything, we link against `libpq` and `libc` dynamically.
