### PR TITLE
Generate debug symbols in release builds as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ categories = [
 ]
 publish = false
 
+[profile.release]
+debug = true
+
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
 diesel = { version = "1.4.5", features = ["chrono", "postgres", "r2d2"] }


### PR DESCRIPTION
We are going to use the release builds in production, so we want them to have DWARF debug symbols that are also useful for CPU profiling.