### PR TITLE
Add GET /snippets route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,12 +1399,12 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7febfdfd4d43facfc7daba20349ebe2c310c6735bd6a2a9255ea8bc425b4cb13"
+checksum = "4a7ab1dfdc75bb8bd2be381f37796b1b300c45a3c9145b34d86715e8dd90bf28"
 dependencies = [
  "atty",
- "base64 0.12.3",
+ "base64 0.13.0",
  "log 0.4.14",
  "memchr",
  "num_cpus",
@@ -1420,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_codegen"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac2c55b2c8b1cdc53add64332defa5fc227f64263b86b4114d1386286d42a3"
+checksum = "1729e687d6d2cf434d174da84fb948f7fef4fac22d20ce94ca61c28b72dbcf9f"
 dependencies = [
  "devise",
  "glob",
@@ -1435,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_contrib"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7954a707f9ca18aa74ca8c1f5d1f900f52a4dceb68e96e3112143f759cfd20e"
+checksum = "6b6303dccab46dce6c7ac26c9b9d8d8cde1b19614b027c3f913be6611bff6d9b"
 dependencies = [
  "log 0.4.14",
  "notify",
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_http"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce364100ed7a1bf39257b69ebd014c1d5b4979b0d365d8c9ab0aa9c79645493d"
+checksum = "6131e6e6d38a9817f4a494ff5da95971451c2eb56a53915579fc9c80f6ef0117"
 dependencies = [
  "cookie",
  "hyper 0.10.16",
@@ -2157,6 +2157,7 @@ dependencies = [
  "chrono",
  "diesel",
  "jsonwebtoken",
+ "percent-encoding 2.1.0",
  "rand 0.7.3",
  "reqwest",
  "rocket",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,14 @@ diesel = { version = "1.4.5", features = ["chrono", "postgres", "r2d2"] }
 jsonwebtoken = "7.2.0"
 rand = "0.7.3"
 reqwest = { version = "0.11.2", features = ["blocking", "json"] }
-rocket = "0.4.5"
-rocket_contrib = {version = "0.4.5", features = ["json"]}
+rocket = "0.4.10"
+rocket_contrib = {version = "0.4.10", features = ["json"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1.25"
 tracing-subscriber = "0.2.16"
 uuid = { version = "0.8.2", features = ["v4"] }
+percent-encoding = "2.1.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/application.rs
+++ b/src/application.rs
@@ -68,6 +68,7 @@ pub fn create_app() -> Result<rocket::Rocket, Box<dyn Error>> {
 
     let routes = routes![
         routes::snippets::create_snippet,
+        routes::snippets::list_snippets,
         routes::snippets::get_snippet,
         routes::syntaxes::get_syntaxes,
         routes::snippets::import_snippet,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,13 +32,13 @@ impl ApiError {
     /// Reason why the request failed.
     pub fn reason(&self) -> &str {
         match self {
-            ApiError::BadRequest(msg) => &msg,
-            ApiError::Forbidden(msg) => &msg,
-            ApiError::NotAcceptable(msg) => &msg,
-            ApiError::Conflict(msg) => &msg,
-            ApiError::NotFound(msg) => &msg,
-            ApiError::InternalError(msg) => &msg,
-            ApiError::UnsupportedMediaType(msg) => &msg,
+            ApiError::BadRequest(msg) => msg,
+            ApiError::Forbidden(msg) => msg,
+            ApiError::NotAcceptable(msg) => msg,
+            ApiError::Conflict(msg) => msg,
+            ApiError::NotFound(msg) => msg,
+            ApiError::InternalError(msg) => msg,
+            ApiError::UnsupportedMediaType(msg) => msg,
         }
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,7 +3,7 @@ mod models;
 mod sql;
 
 pub use errors::StorageError;
-pub use models::{Changeset, DateTime, Direction, ListSnippetsQuery, Snippet};
+pub use models::{Changeset, DateTime, Direction, ListSnippetsQuery, Pagination, Snippet};
 pub use sql::SqlStorage;
 
 /// CRUD interface for storing/loading snippets from a persistent storage.

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -3,7 +3,6 @@ use std::iter;
 use rand::Rng;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
-const DEFAULT_LIMIT_SIZE: usize = 20;
 const DEFAULT_SLUG_LENGTH: usize = 8;
 
 pub type DateTime = chrono::DateTime<chrono::Utc>;
@@ -82,7 +81,7 @@ impl Serialize for Snippet {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Direction {
     /// From older to newer snippets.
     #[allow(dead_code)]
@@ -91,7 +90,7 @@ pub enum Direction {
     Desc,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pagination {
     /// Pagination direction.
     pub direction: Direction,
@@ -104,17 +103,21 @@ pub struct Pagination {
     pub marker: Option<String>,
 }
 
+impl Pagination {
+    pub const DEFAULT_LIMIT_SIZE: usize = 20;
+}
+
 impl Default for Pagination {
     fn default() -> Self {
         Pagination {
             direction: Direction::Desc,
-            limit: DEFAULT_LIMIT_SIZE,
+            limit: Self::DEFAULT_LIMIT_SIZE,
             marker: None,
         }
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ListSnippetsQuery {
     /// If set, only the snippets with the specified title will be returned.
     pub title: Option<String>,

--- a/src/web.rs
+++ b/src/web.rs
@@ -3,5 +3,7 @@ mod content;
 mod tracing;
 
 pub use crate::web::auth::{AuthValidator, BearerAuth, JwtValidator, User};
-pub use crate::web::content::{Input, NegotiatedContentType, Output};
+pub use crate::web::content::{
+    Input, NegotiatedContentType, Output, PaginationLimit, WithHttpHeaders,
+};
 pub use crate::web::tracing::{RequestId, RequestIdHeader, RequestSpan};

--- a/src/web/auth/jwt.rs
+++ b/src/web/auth/jwt.rs
@@ -130,7 +130,7 @@ impl AuthValidator for JwtValidator {
 
                 let key = self
                     .jwks
-                    .find(&key_id)
+                    .find(key_id)
                     .filter(|key| key.alg == header.alg && key.r#use == "sig")
                     .ok_or_else(|| {
                         Error::Configuration(format!("Signing key {:?} can't be found", key_id))
@@ -141,7 +141,7 @@ impl AuthValidator for JwtValidator {
             alg => return Err(Error::Input(format!("Unsupported algorithm: {:?}", alg))),
         };
 
-        match jsonwebtoken::decode::<Claims>(&token, &key, &self.validation) {
+        match jsonwebtoken::decode::<Claims>(token, &key, &self.validation) {
             Ok(data) => Ok(User::Authenticated {
                 name: data.claims.sub,
                 permissions: data.claims.permissions,

--- a/tests/gabbits/list-snippets-errors.yaml
+++ b/tests/gabbits/list-snippets-errors.yaml
@@ -1,0 +1,42 @@
+common:
+  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(\+\d{2}:\d{2})|Z$/
+  - &request_id_regex /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/
+  - &slug_regex /^[a-zA-Z0-9]+$/
+
+fixtures:
+  - XSnippetApiWithSnippets
+
+tests:
+  - name: get next page (marker not found)
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: lEGalACG
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $.message: Snippet with id `lEGalACG` is not found
+    status: 404
+
+  - name: get page (limit is zero)
+    GET: /v1/snippets
+    query_parameters:
+      limit: 0
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $.message: Limit must be an integer between 1 and 20
+    status: 400
+
+  - name: get page (limit is out of bound)
+    GET: /v1/snippets
+    query_parameters:
+      limit: 21
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $.message: Limit must be an integer between 1 and 20
+    status: 400

--- a/tests/gabbits/list-snippets-filtering.yaml
+++ b/tests/gabbits/list-snippets-filtering.yaml
@@ -1,0 +1,131 @@
+common:
+  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(\+\d{2}:\d{2})|Z$/
+  - &request_id_regex /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/
+  - &slug_regex /^[a-zA-Z0-9]+$/
+
+fixtures:
+  - XSnippetApiWithSnippets
+
+tests:
+  - name: get recent snippets with tag=decorator
+    GET: /v1/snippets
+    query_parameters:
+      tag: decorator
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "01"
+      $.[0].title: "caching decorator"
+      $.[0].syntax: "python"
+      $.[0].tags: ["decorator", "caching"]
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: *slug_regex
+      $.[1].content: "03"
+      $.[1].title: "auth decorator"
+      $.[1].syntax: "python"
+      $.[1].tags: ["decorator"]
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.`len`: 2
+    status: 200
+
+  - name: get recent snippets with tag=rocket (no matches)
+    GET: /v1/snippets
+    query_parameters:
+      tag: rocket
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $: []
+    status: 200
+
+  - name: get recent snippets with syntax=rust
+    GET: /v1/snippets
+    query_parameters:
+      syntax: rust
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "02"
+      $.[0].title: "rocket content negotiation guard"
+      $.[0].syntax: "rust"
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.`len`: 1
+    status: 200
+
+  - name: get recent snippets with syntax=clojure (no matches)
+    GET: /v1/snippets
+    query_parameters:
+      syntax: clojure
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $: []
+    status: 200
+
+  - name: get recent snippets with title="caching decorator"
+    GET: /v1/snippets
+    query_parameters:
+      title: caching decorator
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "01"
+      $.[0].title: "caching decorator"
+      $.[0].syntax: "python"
+      $.[0].tags: ["decorator", "caching"]
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.`len`: 1
+    status: 200
+
+  - name: get recent snippets with title=rocket example (no matches)
+    GET: /v1/snippets
+    query_parameters:
+      title: rocket example
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $: []
+    status: 200
+
+  - name: get recent snippets with syntax=python and tag=caching
+    GET: /v1/snippets
+    query_parameters:
+      syntax: python
+      tag: caching
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "01"
+      $.[0].title: "caching decorator"
+      $.[0].syntax: "python"
+      $.[0].tags: ["decorator", "caching"]
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.`len`: 1
+    status: 200

--- a/tests/gabbits/list-snippets-pagination.yaml
+++ b/tests/gabbits/list-snippets-pagination.yaml
@@ -1,0 +1,256 @@
+common:
+  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(\+\d{2}:\d{2})|Z$/
+  - &request_id_regex /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/
+  - &slug_regex /^[a-zA-Z0-9]+$/
+
+fixtures:
+  - XSnippetApiWithSnippets
+
+tests:
+  - name: get recent snippets
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get recent snippets'].$RESPONSE['$.[3].id']
+        rel: next
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "01"
+      $.[0].title: "caching decorator"
+      $.[0].syntax: "python"
+      $.[0].tags: ["decorator", "caching"]
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: *slug_regex
+      $.[1].content: "02"
+      $.[1].title: "rocket content negotiation guard"
+      $.[1].syntax: "rust"
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: *slug_regex
+      $.[2].content: "03"
+      $.[2].title: "auth decorator"
+      $.[2].syntax: "python"
+      $.[2].tags: ["decorator"]
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: *slug_regex
+      $.[3].content: "04"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+    status: 200
+
+  - name: get next page (second page)
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get recent snippets'].$RESPONSE['$.[3].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get next page (second page)'].$RESPONSE['$.[3].id']
+        rel: next
+      - url: /v1/snippets?limit=4
+        rel: prev
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "05"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: *slug_regex
+      $.[1].content: "06"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: *slug_regex
+      $.[2].content: "07"
+      $.[2].title: null
+      $.[2].syntax: null
+      $.[2].tags: []
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: *slug_regex
+      $.[3].content: "08"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+
+  - name: get next page (last page)
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get next page (second page)'].$RESPONSE['$.[3].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get recent snippets'].$RESPONSE['$.[3].id']
+        rel: prev
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "09"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: *slug_regex
+      $.[1].content: "10"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.`len`: 2
+
+  - name: get first page with offset
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get recent snippets'].$RESPONSE['$.[1].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get first page with offset'].$RESPONSE['$.[3].id']
+        rel: next
+      - url: /v1/snippets?limit=4
+        rel: prev
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "03"
+      $.[0].title: "auth decorator"
+      $.[0].syntax: "python"
+      $.[0].tags: ["decorator"]
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: *slug_regex
+      $.[1].content: "04"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: *slug_regex
+      $.[2].content: "05"
+      $.[2].title: null
+      $.[2].syntax: null
+      $.[2].tags: []
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: *slug_regex
+      $.[3].content: "06"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+    status: 200
+
+  - name: get last page
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get next page (second page)'].$RESPONSE['$.[1].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get recent snippets'].$RESPONSE['$.[1].id']
+        rel: prev
+    response_json_paths:
+      $.[0].id: *slug_regex
+      $.[0].content: "07"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: *slug_regex
+      $.[1].content: "08"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: *slug_regex
+      $.[2].content: "09"
+      $.[2].title: null
+      $.[2].syntax: null
+      $.[2].tags: []
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: *slug_regex
+      $.[3].content: "10"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+    status: 200

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ cryptography >= 3.4.6
 gabbi >= 2.1.0
 psycopg2-binary >= 2.8.6
 pytest >= 6.2.1
+requests >= 2.25.1


### PR DESCRIPTION
We already have `POST /snippets` route that creates new snippets, but we
were missing `GET /snippets` route to list recently created snippets.
This patch implements missing route.