### PR TITLE
Fix the edge case of pagination being broken for snippets imported from Mongo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 //! XSnippet API is a RESTful API for a simple web-service for sharing code
 //! snippets on the Internet.
 
+// Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
+#![allow(clippy::nonstandard_macro_braces)]
 #![feature(proc_macro_hygiene, decl_macro)]
 
 #[macro_use]

--- a/tests/gabbits/imported-snippets-pagination.yaml
+++ b/tests/gabbits/imported-snippets-pagination.yaml
@@ -1,0 +1,255 @@
+common:
+  - &datetime_regex /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+(\+\d{2}:\d{2})|Z$/
+  - &request_id_regex /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/
+
+fixtures:
+  - XSnippetApiWithImportedSnippets
+
+tests:
+  - name: get recent snippets
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get recent snippets'].$RESPONSE['$.[3].id']
+        rel: next
+    response_json_paths:
+      $.[0].id: "01"
+      $.[0].content: "01"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: "02"
+      $.[1].content: "02"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: "03"
+      $.[2].content: "03"
+      $.[2].title: null
+      $.[2].syntax: null
+      $.[2].tags: []
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: "04"
+      $.[3].content: "04"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+    status: 200
+
+  - name: get next page (second page)
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get recent snippets'].$RESPONSE['$.[3].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get next page (second page)'].$RESPONSE['$.[3].id']
+        rel: next
+      - url: /v1/snippets?limit=4
+        rel: prev
+    response_json_paths:
+      $.[0].id: "05"
+      $.[0].content: "05"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: "06"
+      $.[1].content: "06"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: "07"
+      $.[2].content: "07"
+      $.[2].title: null
+      $.[2].syntax: null
+      $.[2].tags: []
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: "08"
+      $.[3].content: "08"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+
+  - name: get next page (last page)
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get next page (second page)'].$RESPONSE['$.[3].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get recent snippets'].$RESPONSE['$.[3].id']
+        rel: prev
+    response_json_paths:
+      $.[0].id: "09"
+      $.[0].content: "09"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: "10"
+      $.[1].content: "10"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.`len`: 2
+
+  - name: get first page with offset
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get recent snippets'].$RESPONSE['$.[1].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get first page with offset'].$RESPONSE['$.[3].id']
+        rel: next
+      - url: /v1/snippets?limit=4
+        rel: prev
+    response_json_paths:
+      $.[0].id: "03"
+      $.[0].content: "03"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: "04"
+      $.[1].content: "04"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: "05"
+      $.[2].content: "05"
+      $.[2].title: null
+      $.[2].syntax: null
+      $.[2].tags: []
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: "06"
+      $.[3].content: "06"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+    status: 200
+
+  - name: get last page
+    GET: /v1/snippets
+    query_parameters:
+      limit: 4
+      marker: $HISTORY['get next page (second page)'].$RESPONSE['$.[1].id']
+    response_headers:
+      content-type: application/json
+      x-request-id: *request_id_regex
+    response_link_header:
+      - url: /v1/snippets?limit=4
+        rel: first
+      - url: /v1/snippets?limit=4&marker=$HISTORY['get recent snippets'].$RESPONSE['$.[1].id']
+        rel: prev
+    response_json_paths:
+      $.[0].id: "07"
+      $.[0].content: "07"
+      $.[0].title: null
+      $.[0].syntax: null
+      $.[0].tags: []
+      $.[0].created_at: *datetime_regex
+      $.[0].updated_at: *datetime_regex
+      $.[0].`len`: 7
+
+      $.[1].id: "08"
+      $.[1].content: "08"
+      $.[1].title: null
+      $.[1].syntax: null
+      $.[1].tags: []
+      $.[1].created_at: *datetime_regex
+      $.[1].updated_at: *datetime_regex
+      $.[1].`len`: 7
+
+      $.[2].id: "09"
+      $.[2].content: "09"
+      $.[2].title: null
+      $.[2].syntax: null
+      $.[2].tags: []
+      $.[2].created_at: *datetime_regex
+      $.[2].updated_at: *datetime_regex
+      $.[2].`len`: 7
+
+      $.[3].id: "10"
+      $.[3].content: "10"
+      $.[3].title: null
+      $.[3].syntax: null
+      $.[3].tags: []
+      $.[3].created_at: *datetime_regex
+      $.[3].updated_at: *datetime_regex
+      $.[3].`len`: 7
+
+      $.`len`: 4
+    status: 200

--- a/tests/test_gabbits.py
+++ b/tests/test_gabbits.py
@@ -341,6 +341,86 @@ class XSnippetApiWithSnippets(XSnippetApi):
             response.raise_for_status()
 
 
+class XSnippetApiWithImportedSnippets(XSnippetApiWithCustomAuthProvider):
+    """Start live server of XSnippet API with pre-imported snippets.
+
+    The difference between this fixture and XSnippetApiWithSnippets is that
+    snippets are "imported" rather than created, i.e. they already have some
+    values of the `id` and `created_at` fields that must be preserved. Also,
+    regardless of the order in which snippets are imported, the pagination
+    will work based on the value of `created_at`. When values of `created_at`
+    are identical, creation order is preserved.
+    """
+
+    snippets = [
+        {
+            "id": "06",
+            "content": "06",
+            "created_at": "2021-06-05T15:06:05Z",
+        },
+        {
+            "id": "02",
+            "content": "02",
+            "created_at": "2021-06-05T15:06:09Z",
+        },
+        # the next 3 have the identical `created_at` value, and will be sorted
+        # in the creation order. The test will verify that 03 is considered to
+        # be more recent than 05.
+        {
+            "id": "05",
+            "content": "05",
+            "created_at": "2021-06-05T15:06:08Z",
+        },
+        {
+            "id": "04",
+            "content": "04",
+            "created_at": "2021-06-05T15:06:08Z",
+        },
+        {
+            "id": "03",
+            "content": "03",
+            "created_at": "2021-06-05T15:06:08Z",
+        },
+        {
+            "id": "09",
+            "content": "09",
+            "created_at": "2021-06-05T15:06:02Z",
+        },
+        {
+            "id": "07",
+            "content": "07",
+            "created_at": "2021-06-05T15:06:04Z",
+        },
+        {
+            "id": "01",
+            "content": "01",
+            "created_at": "2021-06-05T15:06:10Z",
+        },
+        {
+            "id": "08",
+            "content": "08",
+            "created_at": "2021-06-05T15:06:03Z",
+        },
+        {
+            "id": "10",
+            "content": "10",
+            "created_at": "2021-06-05T15:06:01Z",
+        },
+    ]
+
+    def start_fixture(self):
+        super().start_fixture()
+
+        token = self.tokens["TOKEN_IMPORT"]
+        session = requests.Session()
+        endpoint = f"http://{XSNIPPET_API_HOST}:{XSNIPPET_API_PORT}/v1/snippets/import"
+
+        for snippet in self.snippets:
+            response = session.post(endpoint, data=json.dumps(snippet),
+                                    headers={"Authorization": f"Bearer {token}"})
+            response.raise_for_status()
+
+
 class LinkHeaderResponseHandler(base.ResponseHandler):
     """Link HTTP header response handler for Gabbi."""
 


### PR DESCRIPTION
When listing snippets, we add filters on `created_at` and `id` to fetch the next page. The latter is only needed because the value of `created_at` is not guaranteed to be unique, so the marker can appear in the next page again. In practice, because we use microsecond precision for datetime fields, duplicates are only expected in tests and, potentially, in snippets imported from Mongo that have second precision.

As is, the code did not work correctly in the edge case when snippets were imported from the old API instance in the reverse (starting from the latest snippets) order, because the assumption, that both `created_at` and `id` monotonically increase together, did not hold true: the additional filter `id < $MARKER_ID` produced an empty result, as "older" (in terms of the value of `created_at`) entries had larger integer ids.

The fix is to change the WHERE clause to compare the value of `created_at` first, and only use `id` to resolve the ties, rather than for every comparison.