### PR TITLE
Tag pre-releases as "nightly" rather than "latest"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             echo "::set-output name=title::${GITHUB_REF#refs/tags/}"
           else
             echo "::set-output name=prerelease::true"
-            echo "::set-output name=release_tag::latest"
+            echo "::set-output name=release_tag::nightly"
             echo "::set-output name=title::Development Build"
           fi
 

--- a/src/web/auth/jwt.rs
+++ b/src/web/auth/jwt.rs
@@ -37,12 +37,15 @@ impl Jwks {
 #[derive(Debug, Deserialize)]
 struct Claims {
     /// Audience (who or that the token is intended for). E.g. "https://api.xsnippet.org".
+    #[allow(unused)]
     aud: String,
     /// Issuer (who created and signed this token). E.g. "https://xsnippet.eu.auth0.com/".
+    #[allow(unused)]
     iss: String,
     /// Subject (whom the token refers to). E.g. "spam@eggs.foo".
     sub: String,
     /// Expiration time (seconds since Unix epoch).
+    #[allow(unused)]
     exp: usize,
     /// Subject permissions (e.g. vec!["import"])
     permissions: Vec<Permission>,


### PR DESCRIPTION
"latest" is a bit special in a sense that Github will automatically add that label to the latest final release. Let's avoid the name clash and call it "nightly" instead.