### PR TITLE
Add a GET /snippet/:id that allows to retrieve the raw content of a snippet as plain text

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -70,6 +70,7 @@ pub fn create_app() -> Result<rocket::Rocket, Box<dyn Error>> {
         routes::snippets::create_snippet,
         routes::snippets::list_snippets,
         routes::snippets::get_snippet,
+        routes::snippets::get_raw_snippet,
         routes::syntaxes::get_syntaxes,
         routes::snippets::import_snippet,
     ];

--- a/src/web.rs
+++ b/src/web.rs
@@ -4,6 +4,6 @@ mod tracing;
 
 pub use crate::web::auth::{AuthValidator, BearerAuth, JwtValidator, User};
 pub use crate::web::content::{
-    Input, NegotiatedContentType, Output, PaginationLimit, WithHttpHeaders,
+    DoNotAcceptAny, Input, NegotiatedContentType, Output, PaginationLimit, WithHttpHeaders,
 };
 pub use crate::web::tracing::{RequestId, RequestIdHeader, RequestSpan};

--- a/src/web/content.rs
+++ b/src/web/content.rs
@@ -232,3 +232,20 @@ impl<'a, 'r> FromRequest<'a, 'r> for NegotiatedContentType {
         }
     }
 }
+
+/// A request guard that only accepts request that specify a specific media type
+/// via the Accept header.
+pub struct DoNotAcceptAny;
+
+impl<'a, 'r> FromRequest<'a, 'r> for DoNotAcceptAny {
+    type Error = ApiError;
+
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
+        match request.accept() {
+            // Accept is passed and it's not */*
+            Some(accept) if !accept.preferred().is_any() => Success(DoNotAcceptAny),
+            // Accept is not passed, or it's not specific (i.e. */*)
+            _ => Forward(()),
+        }
+    }
+}

--- a/tests/gabbits/get-snippet-errors.yaml
+++ b/tests/gabbits/get-snippet-errors.yaml
@@ -35,3 +35,15 @@ tests:
     status: 404
     response_headers:
       x-request-id: *request_id_regex
+
+  - name: retrieve the raw content of a snippet (not found)
+    GET: /v1/snippets/foobar
+    request_headers:
+      accept: text/plain
+    response_headers:
+      content-type: text/plain; charset=utf-8
+    response_strings:
+      - Snippet with id `foobar` is not found
+    status: 404
+    response_headers:
+      x-request-id: *request_id_regex

--- a/tests/gabbits/get-snippet.yaml
+++ b/tests/gabbits/get-snippet.yaml
@@ -80,6 +80,17 @@ tests:
       $.`len`: 7
     status: 200
 
+  - name: retrieve the raw content of a snippet
+    GET: /v1/snippets/$HISTORY['create a new snippet'].$RESPONSE['id']
+    request_headers:
+      accept: "text/plain"
+    response_headers:
+      content-type: text/plain; charset=utf-8
+      x-request-id: *request_id_regex
+    response_strings:
+      - print('Hello, World!')
+    status: 200
+
   - name: retrieve previously created snippet by ID (multiple accept types)
     GET: /v1/snippets/$HISTORY['create a new snippet'].$RESPONSE['id']
     request_headers:


### PR DESCRIPTION
This route can be used to implement the "raw" URIs in the UI w/o the need to support the corresponding nginx Lua rules.

The way we have written out content negotiation system requires us to either add support for a new content type to *all* routes (which we don't want to do at this point), or to use a new request guard to make Rocket dispatch the request to a correct function (which is a bit cumbersome but still easier).