### PR TITLE
Opt-in to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xsnippet-api"
 version = "5.0.0"
 authors = ["XSnippet Team <dev@xsnippet.org>"]
-edition = "2018"
+edition = "2021"
 description = "XSnippet is a simple web-service for sharing code snippets on the Internet."
 readme = "README.md"
 homepage = "https://xsnippet.org/"


### PR DESCRIPTION
This did not actually require any code changes, as we don't use any of
the features that have been updated, except for the new dependency
resolver in Cargo, which will now compile Rocket with some features
disabled:

    > cargo fix --edition
    note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
    This may cause some dependencies to be built with fewer features enabled than previously.
    More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
    When building the following dependencies, the given features will no longer be used:

      cookie v0.11.4 (as host dependency) removed features: aes-gcm, base64, hkdf, hmac, key-expansion, private, rand, secure, sha2, signed
      rocket_http v0.4.10 (as host dependency) removed features: private-cookies

        Checking xsnippet-api v5.0.0 (/home/malor/src/xsnippet-api)
       Migrating src/main.rs from 2018 edition to 2021
        Finished dev [unoptimized + debuginfo] target(s) in 4.55s

All Rust 2021 changes: https://doc.rust-lang.org/edition-guide/rust-2021/index.html