### PR TITLE
Fix GitHub CI warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,18 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - id: release_params
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "::set-output name=prerelease::false"
-            echo "::set-output name=release_tag::${GITHUB_REF#refs/tags/}"
-            echo "::set-output name=title::${GITHUB_REF#refs/tags/}"
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "release_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "title=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=prerelease::true"
-            echo "::set-output name=release_tag::nightly"
-            echo "::set-output name=title::Development Build"
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "release_tag=nightly" >> $GITHUB_OUTPUT
+            echo "title=Development Build" >> $GITHUB_OUTPUT
           fi
 
       - id: create_release
@@ -56,7 +56,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -36,7 +36,7 @@ jobs:
   cargo-clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -93,7 +93,7 @@ jobs:
   cargo-rustdoc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -109,8 +109,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
* actions/checkout@v2 and actions/setup-python@v2 are using a deprecated NodeJS version
* the new setup-python action wants us to specify the Python version explicitly
* setting action output values via stdout is also deprecated (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)