### PR TITLE
Fix the value of GH_REPO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.event.repository.name }}
+          GH_REPO: ${{ env.GITHUB_REPOSITORY }}
 
   build_assets:
     needs: create_release
@@ -81,5 +81,5 @@ jobs:
           popd
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.event.repository.name }}
+          GH_REPO: ${{ env.GITHUB_REPOSITORY }}
           RELEASE_TAG: ${{ needs.create_release.outputs.release_tag }}


### PR DESCRIPTION
See https://github.com/xsnippet/xsnippet-api/actions/runs/8339394829/job/22821304489. Apparentely, `repository.name` does not include the owner name (contrary to what https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables suggests...).