### PR TITLE
Fix asset uploading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,13 @@ jobs:
 
           pushd target/release
           if [ "$RUNNER_OS" == "Windows" ]; then
-            7z a xsnippet-api.exe.7z xsnippet-api.exe
-            gh release upload "$RELEASE_TAG" "xsnippet-api.exe.7z#xsnippet-api-${target_arch}-${target_os}.exe.7z"
+            export ASSET_NAME="xsnippet-api-${target_arch}-${target_os}.exe.7z"
+            7z a $ASSET_NAME xsnippet-api.exe
           else
-            tar cvzf xsnippet-api.gz xsnippet-api
-            gh release upload "$RELEASE_TAG" "xsnippet-api.gz#xsnippet-api-${target_arch}-${target_os}.gz"
+            export ASSET_NAME="xsnippet-api-${target_arch}-${target_os}.gz"
+            tar cvzf $ASSET_NAME xsnippet-api
           fi
+          gh release upload $RELEASE_TAG $ASSET_NAME
           popd
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`gh release upload` allows to set the display label, but, as it turns out, that does not change the names of the assets in the release, and the names are required to be unique. In our case, the names of the Linux and MacOS binaries clash, and the slower of them will fail to upload.