### PR TITLE
ci: fix release creation permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
   build_assets:
     permissions:
       id-token: write
-      contents: read
+      contents: write
       attestations: write
 
     needs: create_release


### PR DESCRIPTION
Per https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token, `contents: write` is required to create new releases and upload artifacts.