### PR TITLE
ci: quick fix for the releases workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,15 @@ jobs:
 
       - id: build
         run: |
-          export HOST=$(rustc +nightly -Z unstable-options --print target-spec-json | jq --raw-output '."llvm-target"')
+          rustc --print cfg | grep = > rustc.vars
+          source rustc.vars
+
+          if [ -z "${target_env}" ]; then
+            export HOST="${target_arch}-${target_vendor}-${target_os}"
+          else
+            export HOST="${target_arch}-${target_vendor}-${target_os}-${target_env}"
+          fi
+
           if [ "$HOST" = "$TARGET" ]; then
             cargo build --release --target ${TARGET}
           else
@@ -86,7 +94,7 @@ jobs:
           fi
 
           pushd target/${TARGET}/release
-          if [ "$TARGET" =~ "windows" ]; then
+          if [[ "$TARGET" =~ "windows" ]]; then
             7z a $ASSET_NAME xsnippet-api.exe
           else
             tar cvzf $ASSET_NAME xsnippet-api


### PR DESCRIPTION
https://github.com/xsnippet/xsnippet-api/pull/173 had a couple of issues:

* String regex test in Bash requires [[ ]] instead of [ ]
* JSON output in rustc is only available when the nightly toolchain is installed. Instead, we can form the target value manually