### PR TITLE
Build and link with openssl statically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.1+3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1289,7 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2806,6 +2816,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "jsonwebtoken",
+ "openssl-sys",
  "percent-encoding",
  "rand 0.7.3",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tracing = "0.1.25"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 percent-encoding = "2.1.0"
+openssl-sys = { version = "0.9.104", features = ["vendored"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,0 @@
-[build]
-pre-build = [
-    "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH libpq-dev:$CROSS_DEB_ARCH"
-]


### PR DESCRIPTION
Dynamic linking with openssl does not work well with cross-compilation: the Docker image `cross` uses for aarch64 is based on Ubuntu Xenial that has libssl1.0.0, while the ones available on Raspbian (and other modern distros) are libssl1.1 and libssl3.

Instead, we can use the feature of `openssl-sys` that allows to build and statically link openssl to avoid the hassle with shared object versions that vary between Linux distros.

This makes Cross.toml completely unnecessary.