### PR TITLE
Make master green again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           override: true
 
       - name: Setup PostgreSQL
-        uses: ikalnytskyi/action-setup-postgres@v6
+        uses: ikalnytskyi/action-setup-postgres@v7
 
       - id: detect_host
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           override: true
 
       - name: Setup PostgreSQL
-        uses: ikalnytskyi/action-setup-postgres@v6
+        uses: ikalnytskyi/action-setup-postgres@v7
         id: postgres
 
       - name: Set ROCKET_DATABASE_URL
@@ -127,7 +127,7 @@ jobs:
           override: true
 
       - name: Setup PostgreSQL
-        uses: ikalnytskyi/action-setup-postgres@v6
+        uses: ikalnytskyi/action-setup-postgres@v7
         id: postgres
 
       - run: |

--- a/src/storage/sql/mod.rs
+++ b/src/storage/sql/mod.rs
@@ -303,6 +303,7 @@ impl Storage for SqlStorage {
         Ok(snippet)
     }
 
+    #[allow(dead_code)]
     async fn update(&self, snippet: &Snippet) -> Result<Snippet, StorageError> {
         // load the snippet from the db to check if we need to update anything
         let persisted_state = self.get(&snippet.id).await?;

--- a/src/web/tracing.rs
+++ b/src/web/tracing.rs
@@ -64,6 +64,7 @@ impl Fairing for RequestIdHeader {
 /// A natural point of integration with Rocket is a fairing, which allows us to
 /// execute some code before and after each HTTP request, which is exactly what
 /// we need for determining the boundaries of a request span.
+#[allow(dead_code)]
 pub struct RequestSpan;
 
 // TODO: Now that Rocket is using async internally, this is not guaranteed to


### PR DESCRIPTION
The new Rust compiler got a lot smarter at spotting "dead code" and started complaining about some unused bits. Turns out the snippet update feature was never fully finished — but that’s no reason to rip out parts of the storage subsystem.

On top of that, GitHub CI switched to a new macOS runner that doesn’t come with PostgreSQL pre-installed anymore. So we had to bump the action-setup-postgres version to get it running smoothly.